### PR TITLE
iOS Remote message: macOS promo May 2023

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,43 @@
 {
-  "version": 2,
-  "messages": [],
-  "rules": []
+  "version": 3,
+  "messages": [
+    {
+      "id": "macos_promo_may2023",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Get DuckDuckGo Browser for Mac",
+        "descriptionText": "Search privately and block trackers and annoying cookie pop-ups on your Mac for free!",
+        "placeholder": "MacComputer",
+        "primaryActionText": "Learn More",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/mac?rmf=mac"
+        }
+      },
+      "matchingRules": [
+        1
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "id": 1,
+      "attributes": {
+        "appVersion": {
+          "min": "7.74.0"
+        },
+        "daysSinceInstalled": {
+          "min": 3,
+          "max": 9
+        },
+        "locale": {
+          "value": [
+            "en-CA",
+            "en-GB",
+            "en-US"
+          ]
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1204584947434733/f

**Description**

Added 1 remote message to promote macOS app installs as part of experiment https://app.asana.com/0/1142021229838617/1204550785274084/f
 
**Steps to test this PR**
1. Checkout `fix/anya/design-system-home-message-layout` branch from the iOS repo
2. Go to RemoteMessageRequest and replace the debug URL with [1109066934305177600](https://jsonblob.com/api/jsonBlob/1109066934305177600)
3. Launch the app 
4. Confirm message presents as below:
     <img width="390" alt="image" src="https://github.com/duckduckgo/remote-messaging-config/assets/91189922/3fdc56dc-281b-4594-8010-b6316b8c97f1">

6. Tap the 'Learn More' button and confirm a tab is opened with url `https://duckduckgo.com/mac?rmf=mac`