### PR TITLE
iOS: Removes macOS promo may 2023

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,43 +1,5 @@
 {
-  "version": 3,
-  "messages": [
-    {
-      "id": "macos_promo_may2023",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Get DuckDuckGo Browser for Mac",
-        "descriptionText": "Search privately and block trackers and annoying cookie pop-ups on your Mac for free!",
-        "placeholder": "MacComputer",
-        "primaryActionText": "Learn More",
-        "primaryAction": {
-          "type": "url",
-          "value": "https://duckduckgo.com/mac?rmf=mac"
-        }
-      },
-      "matchingRules": [
-        1
-      ]
-    }
-  ],
-  "rules": [
-    {
-      "id": 1,
-      "attributes": {
-        "appVersion": {
-          "min": "7.74.0"
-        },
-        "daysSinceInstalled": {
-          "min": 3,
-          "max": 9
-        },
-        "locale": {
-          "value": [
-            "en-CA",
-            "en-GB",
-            "en-US"
-          ]
-        }
-      }
-    }
-  ]
+  "version": 4,
+  "messages": [],
+  "rules": []
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1204586363233483/f 

Description

Removes macOS promo.

Steps to test this PR

- [ ] Go to RemoteMessageRequest and replace the debug URL with https://staticcdn.duckduckgo.com/remotemessaging/config/staging/pre/ios-config.json
- [ ] Launch the app
- [ ] Confirm no remote message is presented