### PR TITLE
Revert "desktop browser promo message for iOS and Android (#23)"

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,37 +1,5 @@
 {
-  "version": 5,
-  "messages": [
-    {
-      "id": "macos_promo_oct2023",
-      "content": {
-        "messageType": "promo_single_action",
-        "titleText": "Did you know our free browser is available on Windows & Mac?",
-        "descriptionText": "Visit <b>duckduckgo.com/browser</b> on your computer to download.",
-        "placeholder": "NewForMacAndWindows",
-        "actionText": "Send Link",
-        "action": {
-          "type": "share",
-          "value": "Visit https://duckduckgo.com/app",
-          "additionalParameters": {
-            "title": "Get DuckDuckGo Browser for Mac or Windows"
-          }
-        }
-      },
-      "matchingRules": [
-        1
-      ]
-    }
-  ],
-  "rules": [
-    {
-      "id": 1,
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US"
-          ]
-        }
-      }
-    }
-  ]
+  "version": 4,
+  "messages": [],
+  "rules": []
 }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,35 +1,5 @@
 {
-  "version": 7,
-  "messages": [
-    {
-      "id": "macos_promo_may2023",
-      "content": {
-        "messageType": "promo_single_action",
-        "titleText": "Did you know our free browser is available on Windows & Mac?",
-        "descriptionText": "Visit <b>duckduckgo.com/browser</b> on your computer to download.",
-        "placeholder": "NewForMacAndWindows",
-        "actionText": "Send Link",
-        "action": {
-          "type": "share",
-          "value": "Visit https://duckduckgo.com/browser",
-          "additionalParameters": { "title": "Get DuckDuckGo Browser for Mac or Windows" }
-        }
-      },
-      "matchingRules": [
-        1
-      ]
-    }
-  ],
-  "rules": [
-    {
-      "id": 1,
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US"
-          ]
-        }
-      }
-    }
-  ]
+  "version": 6,
+  "messages": [],
+  "rules": []
 }


### PR DESCRIPTION
This reverts commit dc43c4359a50e0364002c210beb33f9beb427b8a.

The iOS app is seeing a high rate of crashes right after the original PR was merged.