### PR TITLE
Remove region from GA workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -19,6 +19,5 @@ jobs:
         AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: 'us-east-1'
         SOURCE_DIR: 'live/android-config' 
         DEST_DIR: 'remotemessaging/config/v1'


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1205728041925304/f

**Description**
Publishing production config seems broken. We have another GA workflow to publish a config in staging that is working fine. Both workflows use same credentials, and should work in the same way.

The only difference I've seen is that production uses a `region`. Removing the region just in case that's the root issue.