### PR TITLE
Allow manually triggering the workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'live/android-config/android-config.json'
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Add `workflow_dispatch:` so we can trigger Github Action manually