### PR TITLE
Desktop browser promo message for iOS (Nov desktop promo)

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,39 @@
 {
-  "version": 12,
-  "messages": [],
-  "rules": []
+  "version": 13,
+  "messages": [
+    {
+      "id": "macos_promo_may2023",
+      "content": {
+        "messageType": "promo_single_action",
+        "titleText": "Did you know our free browser is available on Windows & Mac?",
+        "descriptionText": "Visit <b>duckduckgo.com/browser</b> on your computer to download.",
+        "placeholder": "NewForMacAndWindows",
+        "actionText": "Send Link",
+        "action": {
+          "type": "share",
+          "value": "https://duckduckgo.com/browser",
+          "additionalParameters": { "title": "Get DuckDuckGo Browser for Mac or Windows" }
+        }
+      },
+      "matchingRules": [
+        1
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "id": 1,
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US"
+          ]
+        },
+        "osApi": {
+          "min": "16.0.0",
+          "max": "18.0.0"
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
**Requests**
* iOS: https://app.asana.com/0/0/1205952868415455/f

**Test**
(Run this test on different emulators to ensure no issues with ios versions)

_Test flow_
- [ ] install current develop
- [ ] open the app (that should download the current production config)
- [ ] Replace Remote message url for the staging one
- [ ] install version with hardcoded url
- [ ] Open the app (that should download the new config)
- [ ] skip onboarding
- [ ] ensure you see the promo
- [ ] click Send Link
- [ ] ensure the bottom sheet appears
- [ ] Select and app and share
- [ ] ensure link is shared correctly

_Test versions_
- [ ] ios 15 should not see the promo
- [ ] ios 16, 17, 18 should see the promo

**Merge Schedule**

* Monday 27 Nov, AM

**Screenshots**

![image2](https://github.com/duckduckgo/remote-messaging-config/assets/81197/56680159-564f-48f3-a0ad-c7b581ae8db4)
![Simulator Screenshot - iPhone 14 Pro Max - 2023-09-21 at 15 14 21](https://github.com/duckduckgo/remote-messaging-config/assets/81197/acd7c976-cd94-4da9-b270-51fd800a5ccf)
![Simulator Screenshot - iPhone 14 Pro Max - 2023-09-21 at 15 14 14](https://github.com/duckduckgo/remote-messaging-config/assets/81197/c5f0fa8a-b86f-412b-8460-8084d1f90ab9)