### PR TITLE
Enable remote message for android (Nov desktop promo)

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,22 +1,20 @@
 {
-  "version": 11,
+  "version": 12,
   "messages": [
     {
-      "id": "default_browser",
+      "id": "macos_promo_oct2023",
       "content": {
-        "messageType": "big_two_action",
-        "titleText": "Browse privately every time",
-        "descriptionText": "Block trackers, cookie pop-ups, targeted ads, and more. Make DuckDuckGo your default browser today.",
-        "placeholder": "DDGAnnounce",
-        "primaryActionText": "Set As Default",
-        "primaryAction": {
-          "type": "defaultBrowser",
-          "value": ""
-        },
-        "secondaryActionText": "No Thanks",
-        "secondaryAction": {
-          "type": "dismiss",
-          "value": ""
+        "messageType": "promo_single_action",
+        "titleText": "Did you know our free browser is available on Windows & Mac?",
+        "descriptionText": "Visit <b>duckduckgo.com/browser</b> on your computer to download.",
+        "placeholder": "NewForMacAndWindows",
+        "actionText": "Send Link",
+        "action": {
+          "type": "share",
+          "value": "Visit https://duckduckgo.com/app",
+          "additionalParameters": {
+            "title": "Get DuckDuckGo Browser for Mac or Windows"
+          }
         }
       },
       "matchingRules": [
@@ -30,18 +28,8 @@
       "attributes": {
         "locale": {
           "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
+            "en-US"
           ]
-        },
-        "defaultBrowser": {
-          "value": false
-        },
-        "expVariant": {
-          "value": "zj",
-          "fallback": false
         }
       }
     }


### PR DESCRIPTION
**Requests**
* Android: https://app.asana.com/0/0/1205952868415453/f

**Test**

_Test flow_
- [x] Replace Remote message url for the staging one
- [x] Open the app
- [x] skip onboarding
- [x] ensure you see the promo
- [x] click Send Link
- [x] ensure the bottom sheet appears
- [x] Select and app and share
- [x] ensure link is shared correctly

_Test flow 2_
- [x] Fresh install
- [x] Go to JsonBlob and create a json with the old promo (use version 10)
- [x] Replace Remote message url with jsonBlob endpoint
- [x] Run the app
- [x] Skip onboarding
- [x] Ensure you see the promo, but do not interact with it
- [x] Update JsonBlob with empty promo (bump version to 11)
- [x] Open the app again (you can use fire button)
- [x] Ensure no RMF
- [x] Replace Remote message url for the staging one
- [x] Open the app
- [x] ensure you see the promo
- [x] click Send Link
- [x] ensure the bottom sheet appears
- [x] Select and app and share
- [x] ensure link is shared correctly

**Merge Schedule**

* Monday 27 Nov, AM

![image](https://github.com/duckduckgo/remote-messaging-config/assets/4747865/7ced638e-7c16-47a4-850a-4bab30a86f93)
![image](https://github.com/duckduckgo/remote-messaging-config/assets/4747865/51db4071-cbff-4d9b-9a74-ea6bb0bb654b)

