### PR TITLE
Disable iOS VPN survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,43 +1,5 @@
 {
-  "version": 16,
-  "messages": [
-    {
-      "id": "vpn_survey",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Network Protection Survey",
-        "descriptionText": "Please tell us your thoughts about DuckDuckGo's Network Protection beta.",
-        "placeholder": "VPNAnnounce",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey_url",
-          "value": "https://www.research.net/r/NetPiOSWaitlistBetaSurveyFinal2"
-        }
-      },
-      "matchingRules": [
-        1
-      ]
-    }
-  ],
-  "rules": [
-    {
-      "id": 1,
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US"
-          ]
-        },
-        "isNetPWaitlistUser": {
-          "value": true
-        },
-        "daysSinceNetPEnabled": {
-          "min": 5
-        },
-        "appVersion": {
-          "min": "7.104.0.0"
-        }
-      }
-    }
-  ]
+  "version": 17,
+  "messages": [],
+  "rules": []
 }


### PR DESCRIPTION
Task: https://app.asana.com/0/0/1206470564621802/f

This PR removes the VPN iOS survey added in https://github.com/duckduckgo/remote-messaging-config/pull/40.

