### PR TITLE
Re-enable the iOS VPN survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,43 @@
 {
   "version": 17,
-  "messages": [],
-  "rules": []
+  "messages": [
+    {
+      "id": "vpn_survey",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Network Protection Survey",
+        "descriptionText": "Please tell us your thoughts about DuckDuckGo's Network Protection beta.",
+        "placeholder": "VPNAnnounce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey_url",
+          "value": "https://www.research.net/r/NetworkProtectioniOSWaitlistBetaSurvey"
+        }
+      },
+      "matchingRules": [
+        1
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "id": 1,
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US"
+          ]
+        },
+        "isNetPWaitlistUser": {
+          "value": true
+        },
+        "daysSinceNetPEnabled": {
+          "min": 5
+        },
+        "appVersion": {
+          "min": "7.106.0.4"
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Task: https://app.asana.com/0/0/1206470564621802/f

This PR re-enables the survey that was disabled in https://github.com/duckduckgo/remote-messaging-config/pull/42 due to issues with the iOS app loading URLs correctly.

This survey is identical to the one originally added in https://github.com/duckduckgo/remote-messaging-config/pull/40, except with the latest RMF version number and now targeting `7.106.0.4` as its minimum, which went live last week.

Testing Steps:

1. Update `RemoteMessageRequest` with the staging URL
2. Update `RemoteMessaging` around line 179 to set `isNetPWaitlistUser: true` and `daysSinceNetPEnabled: 5`
3. Change your device to use United States as its region
4. Run the app and verify that the message appears
5. Change `daysSinceNetPEnabled` to `3`
6. Reset the app to make sure that the previously cached message is removed
7. Run the app again and make sure that the message does not appear
8. Do the above steps again but set the app version to `7.103.0`, to make sure that the version requirement is respected