### PR TITLE
iOS app survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -25,7 +25,7 @@
         "titleText": "Help us improve the app!",
         "descriptionText": "Take our short anonymous survey and share your feedback.",
         "placeholder": "RemoteMessageDDGAnnouncement",
-        "primaryActionText": "Take the Survey",
+        "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey_url",
           "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240200?list=2"

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -60,7 +60,8 @@
       "id": 2,
       "attributes": {
         "daysSinceInstalled": {
-          "min": 5
+          "min": 5,
+          "max": 8
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -24,7 +24,7 @@
         "messageType": "big_single_action",
         "titleText": "Help us improve the app!",
         "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "RemoteMessageDDGAnnouncement",
+        "placeholder": "RemoteMessageAnnouncement",
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey_url",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -17,6 +17,23 @@
       "matchingRules": [
         1
       ]
+    },
+    {
+      "id": "ddg_ios_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help us improve the app!",
+        "descriptionText": "Take our short anonymous survey and share your feedback.",
+        "placeholder": "RemoteMessageDDGAnnouncement",
+        "primaryActionText": "Take the Survey",
+        "primaryAction": {
+          "type": "survey_url",
+          "value": "https://www.research.net/r/NetworkProtectioniOSWaitlistBetaSurvey"
+        }
+      },
+      "matchingRules": [
+        2
+      ]
     }
   ],
   "rules": [
@@ -36,6 +53,14 @@
         },
         "appVersion": {
           "min": "7.106.0.4"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 5
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 17,
+  "version": 18,
   "messages": [
     {
       "id": "vpn_survey",
@@ -28,7 +28,7 @@
         "primaryActionText": "Take the Survey",
         "primaryAction": {
           "type": "survey_url",
-          "value": "https://www.research.net/r/NetworkProtectioniOSWaitlistBetaSurvey"
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240200?list=2"
         }
       },
       "matchingRules": [

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -62,6 +62,9 @@
         "daysSinceInstalled": {
           "min": 5,
           "max": 8
+        },
+        "appVersion": {
+          "min": "7.106.0.4"
         }
       }
     }


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1206503058337953/f

This PR adds a survey for iOS app users.

**Testing instructions:**

1. Update `RemoteMessageRequest` to include the sample URL attached in the comments below
2. Update `shouldProcessConfig` to always return true
3. Now we need to test that the install date range is working. We have no method in the Debug menu for overriding this (expect some improvements there soon!), so for now you'll need to use a local copy of BSK and search for the line `case let matchingAttribute as DaysSinceInstalledMatchingAttribute`
4. Underneath the line mentioned above, you can override `daysSinceInstall` value to check the range. Try it with `0`, `5`, and `10`, and expect that the message only appears for the `5` case
5. Finally, set the value back to one that matches the range, and check that opening the link correctly opens the survey