### PR TITLE
Remove the Feb iOS survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -17,23 +17,6 @@
       "matchingRules": [
         1
       ]
-    },
-    {
-      "id": "ddg_ios_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "RemoteMessageAnnouncement",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey_url",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240200?list=2"
-        }
-      },
-      "matchingRules": [
-        2
-      ]
     }
   ],
   "rules": [
@@ -50,18 +33,6 @@
         },
         "daysSinceNetPEnabled": {
           "min": 5
-        },
-        "appVersion": {
-          "min": "7.106.0.4"
-        }
-      }
-    },
-    {
-      "id": 2,
-      "attributes": {
-        "daysSinceInstalled": {
-          "min": 5,
-          "max": 8
         },
         "appVersion": {
           "min": "7.106.0.4"

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 18,
+  "version": 19,
   "messages": [
     {
       "id": "vpn_survey",


### PR DESCRIPTION
This PR removes the survey added in https://github.com/duckduckgo/remote-messaging-config/pull/45.

**Testing Steps:**

1. Check that the version number has been bumped correctly
2. Update `RemoteMessageRequest` to include the sample URL attached in the comments below
3. Update `shouldProcessConfig` to always return true
4. Check that the manifest that is downloaded is read correctly, and no survey appears