### PR TITLE
Remove VPN survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,43 +1,5 @@
 {
-  "version": 19,
-  "messages": [
-    {
-      "id": "vpn_survey",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Network Protection Survey",
-        "descriptionText": "Please tell us your thoughts about DuckDuckGo's Network Protection beta.",
-        "placeholder": "VPNAnnounce",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey_url",
-          "value": "https://www.research.net/r/NetworkProtectioniOSWaitlistBetaSurvey"
-        }
-      },
-      "matchingRules": [
-        1
-      ]
-    }
-  ],
-  "rules": [
-    {
-      "id": 1,
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US"
-          ]
-        },
-        "isNetPWaitlistUser": {
-          "value": true
-        },
-        "daysSinceNetPEnabled": {
-          "min": 5
-        },
-        "appVersion": {
-          "min": "7.106.0.4"
-        }
-      }
-    }
-  ]
+  "version": 20,
+  "messages": [],
+  "rules": []
 }


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1206816642956057/f

This PR removes the VPN survey.

**Testing steps:**

1. Update `RemoteMessageRequest` with the staging URL
2. Update `RemoteMessaging` around line 179 to set `isNetPWaitlistUser: true` and `daysSinceNetPEnabled: 5`
3. Change your device to use United States as its region
4. Run the app and verify that the message does NOT appear