### PR TITLE
Add iOS beta ending remote message

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -2,7 +2,7 @@
   "version": 21,
   "messages": [
     {
-      "id": "vpn_survey",
+      "id": "ios_vpn_beta_ending",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Thanks for testing DuckDuckGo VPN!",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -32,7 +32,7 @@
           "value": true
         },
         "daysSinceNetPEnabled": {
-          "min": 1
+          "min": 0
         },
         "appVersion": {
           "min": "7.106.0.4"

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,43 @@
 {
-  "version": 20,
-  "messages": [],
-  "rules": []
+  "version": 21,
+  "messages": [
+    {
+      "id": "vpn_survey",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Thanks for testing DuckDuckGo VPN!",
+        "descriptionText": "The free, early access period is ending soon.",
+        "placeholder": "VPNAnnounce",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      },
+      "matchingRules": [
+        1
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "id": 1,
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US"
+          ]
+        },
+        "isNetPWaitlistUser": {
+          "value": true
+        },
+        "daysSinceNetPEnabled": {
+          "min": 1
+        },
+        "appVersion": {
+          "min": "7.106.0.4"
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
**Task:** https://app.asana.com/0/0/1206830691896446/f

Request: https://app.asana.com/0/0/1206874099539049/f

This PR adds the VPN beta ending remote message.

**Testing Instructions:**

1. Update `RemoteMessageRequest` with the staging URL mentioned in the comments below
2. Update `RemoteMessaging` around line 182 to set `isNetPWaitlistUser: true` and `daysSinceNetPEnabled: 0`
3. Change your device to use United States as its region
4. Run the app and verify that the message appears
5. Change `daysSinceNetPEnabled` to `-1`
6. Reset the app to make sure that the previously cached message is removed
7. Make sure that the message does not appear when you run the app again

---

![Beta Ending Message](https://github.com/duckduckgo/remote-messaging-config/assets/183774/846654c7-9568-4ac1-bb8e-ae76001a56f0)
