### PR TITLE
Enable remote message for VPN Beta Ending on Android

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,32 @@
 {
-  "version": 14,
-  "messages": [],
-  "rules": []
+  "version": 15,
+  "messages": [
+    {
+      "id": "beta-ending-20240318",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Thanks for testing DuckDuckGo VPN!",
+        "descriptionText": "The free, early access period is ending soon.",
+        "placeholder": "Announce",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+            "type": "dismiss",
+            "value": ""
+        }
+      },
+      "matchingRules": [
+        1
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "id": 1,
+      "attributes": {
+        "netpOnboarded": {
+          "value": true
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Requests

Android: https://app.asana.com/0/0/1206865077273029/f

Test flow VPN enabled
- [ ] Install develop build
- [ ] Enable VPN (through waitlist invite code https://app.asana.com/0/1203137811378537/1204303483337129/f)
- [ ] Replace Remote message url to staging (https://staticcdn.duckduckgo.com/remotemessaging/config/staging/android-config.json)
- [ ] Re-install build (Restart it a few times)
- [ ] Verify that remote message is shown in new tab


Test flow VPN disabled
- [ ] Install develop build
- [ ]  Replace Remote message url to staging (https://staticcdn.duckduckgo.com/remotemessaging/config/staging/android-config.json)
- [ ] Re-install build
- [ ] Verify that remote message is NOT shown


<img width="333" alt="Screenshot 2024-03-18 at 13 40 35" src="https://github.com/duckduckgo/remote-messaging-config/assets/2943941/84d2b568-0ddb-410a-83bf-607731aca27a">
