### PR TITLE
Enable iOS survey: May 2024

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,36 @@
 {
-  "version": 23,
-  "messages": [],
-  "rules": []
+  "version": 24,
+  "messages": [
+    {
+      "id": "ddg_ios_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help us improve the app!",
+        "descriptionText": "Take our short anonymous survey and share your feedback.",
+        "placeholder": "RemoteMessageAnnouncement",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey_url",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240200?list=2"
+        }
+      },
+      "matchingRules": [
+        2
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "id": 2,
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 5,
+          "max": 8
+        },
+        "appVersion": {
+          "min": "7.106.0.4"
+        }
+      }
+    }
+  ]
 }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -15,13 +15,13 @@
         }
       },
       "matchingRules": [
-        2
+        1
       ]
     }
   ],
   "rules": [
     {
-      "id": 2,
+      "id": 1,
       "attributes": {
         "daysSinceInstalled": {
           "min": 5,


### PR DESCRIPTION
Task: https://app.asana.com/0/0/1201919021783680/f

This PR enables the monthly survey for iOS app users.

**Testing instructions:**

1. Update `RemoteMessageRequest` to include the sample URL attached in the comments below
2. Update `shouldProcessConfig` to always return true
3. Now we need to test that the install date range is working. We have no method in the Debug menu for overriding this so for now you'll need to use a local copy of BSK and search for the line `case let matchingAttribute as DaysSinceInstalledMatchingAttribute`
4. Underneath the line mentioned above, you can override `daysSinceInstall` value to check the range. Try it with `0`, `5`, and `10`, and expect that the message only appears for the `5` case
5. Finally, set the value back to one that matches the range, and check that opening the link correctly opens the survey