### PR TITLE
iOS Privacy Pro subscriber survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -29,9 +29,11 @@
           "before": 0.9
       },
       "attributes": {
-        "daysSinceInstalled": {
-          "min": 0,
-          "max": 3
+        "pproEligible": {
+          "value": true
+        },
+        "pproSubscriber": {
+          "value": true
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -11,7 +11,7 @@
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240308",
+          "value": "https://duckduckgo.com",
           "additionalParameters": {
             "queryParams": "atb;var;delta;osv;ddgv;mo;da"
           }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -32,6 +32,12 @@
         "pproDaysSinceSubscribed": {
           "min": 5
         },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": "active"
+        },
         "appVersion": {
           "min": "7.106.0.4"
         }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 24,
+  "version": 25,
   "messages": [
     {
       "id": "ddg_ios_survey_1",
@@ -10,8 +10,11 @@
         "placeholder": "RemoteMessageAnnouncement",
         "primaryActionText": "Take Survey",
         "primaryAction": {
-          "type": "survey_url",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240200?list=2"
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240308",
+          "additionalParameters": {
+            "queryParams": "atb;var;delta;av;ddgv;man;mo;da;src"
+          }
         }
       },
       "matchingRules": [
@@ -22,13 +25,13 @@
   "rules": [
     {
       "id": 1,
+      "targetPercentile": {
+          "before": 0.9
+      },
       "attributes": {
         "daysSinceInstalled": {
-          "min": 5,
-          "max": 8
-        },
-        "appVersion": {
-          "min": "7.106.0.4"
+          "min": 0,
+          "max": 3
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,39 @@
 {
-  "version": 27,
-  "messages": [],
-  "rules": []
+  "version": 28,
+  "messages": [
+    {
+      "id": "ddg_ios_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help us improve the app!",
+        "descriptionText": "Take our short anonymous survey and share your feedback.",
+        "placeholder": "RemoteMessageAnnouncement",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240308",
+          "additionalParameters": {
+            "queryParams": "atb;var;delta;osv;ddgv;mo;da"
+          }
+        }
+      },
+      "matchingRules": [
+        1
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "id": 1,
+      "targetPercentile": {
+          "before": 0.9
+      },
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 0,
+          "max": 3
+        }
+      }
+    }
+  ]
 }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -7,7 +7,7 @@
         "messageType": "big_single_action",
         "titleText": "Tell Us Your Thoughts on Privacy Pro",
         "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
-        "placeholder": "PrivacyPro",
+        "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -2,18 +2,18 @@
   "version": 30,
   "messages": [
     {
-      "id": "ddg_ios_survey_1",
+      "id": "ddg_privacy_pro_survey_1",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
+        "titleText": "Tell Us Your Thoughts on Privacy Pro",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
         "placeholder": "PrivacyPro",
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",
-          "value": "https://duckduckgo.com",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3",
           "additionalParameters": {
-            "queryParams": "atb;var;delta;osv;ddgv;mo;da"
+            "queryParams": "atb;var;delta;osv;ddgv;mo;da;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
         }
       },
@@ -25,21 +25,15 @@
   "rules": [
     {
       "id": 1,
-      "targetPercentile": {
-          "before": 0.9
-      },
       "attributes": {
-        "pproEligible": {
-          "value": true
-        },
         "pproSubscriber": {
           "value": true
         },
         "pproDaysSinceSubscribed": {
           "min": 5
         },
-        "pproDaysUntilExpiryOrRenewal": {
-          "min": 5
+        "appVersion": {
+          "min": "7.106.0.4"
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 28,
+  "version": 30,
   "messages": [
     {
       "id": "ddg_ios_survey_1",
@@ -7,7 +7,7 @@
         "messageType": "big_single_action",
         "titleText": "Help us improve the app!",
         "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "RemoteMessageAnnouncement",
+        "placeholder": "PrivacyPro",
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -2,7 +2,7 @@
   "version": 30,
   "messages": [
     {
-      "id": "ddg_privacy_pro_survey_1",
+      "id": "ddg_privacy_pro_survey_test",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Your Thoughts on Privacy Pro",
@@ -13,7 +13,7 @@
           "type": "survey",
           "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3",
           "additionalParameters": {
-            "queryParams": "atb;var;delta;osv;ddgv;mo;da;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+            "queryParams": "atb;var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
         }
       },

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -34,6 +34,12 @@
         },
         "pproSubscriber": {
           "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 5
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "min": 5
         }
       }
     }


### PR DESCRIPTION
**Background:**

Task: https://app.asana.com/0/1200848785558646/1207585156849487/f

This PR adds a Privacy Pro subscriber survey, for users with 14+ days of activity.

**How to test:**

1. Update the iOS app to use the staging URL below
2. Now we need a Privacy Pro account with the right attributes - this can be difficult as you can't easily fake the account's age, so instead just sign into any Privacy Pro account and modify the values passed to `UserAttributeMatcher` in `RemoteMessaging.swift`

In this case, you want an account that is subscribed for at least 14 days, and was purchased via Apple. In my case I only have a Stripe account, so I manually edited `UserAttributeMatcher` to take an `apple `purchase platform. If you want to test this with a legit account, contact Michal.

Screenshot attached of this message with my real Privacy Pro account, but with the purchase platform overridden:

![Simulator Screenshot - iPhone 15 Pro - 2024-06-16 at 20 05 23](https://github.com/duckduckgo/remote-messaging-config/assets/183774/58e33047-9780-45b9-9b6f-5666129f0f27)
