### PR TITLE
iOS email campaign (May 2024)

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,304 @@
 {
-  "version": 25,
-  "messages": [],
-  "rules": []
+  "version": 26,
+  "messages": [
+    {
+      "id": "email_campaign_may24",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Protect Your Inbox",
+        "descriptionText": "Get your @duck.com forwarding address and start blocking hidden email trackers\u00A0today!",
+        "placeholder": "Announce",
+        "primaryActionText": "Sign Up",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/email"
+        }
+      },
+      "matchingRules": [1, 2, 3, 4, 5, 6, 7],
+      "exclusionRules": [8]
+    }
+  ],
+  "rules": [
+    {
+      "id": 1,
+      "attributes": {
+        "appVersion": {
+          "min": "7.118.0"
+        },
+        "atb": {
+          "value": "v430-1"
+        },
+        "daysSinceInstalled": {
+          "min": 0,
+          "max": 3
+        },
+        "emailEnabled": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "en-AU",
+            "en-BZ",
+            "en-CA",
+            "en-cb",
+            "en-GB",
+            "en-IE",
+            "en-IN",
+            "en-JM",
+            "en-MT",
+            "en-MY",
+            "en-NZ",
+            "en-PH",
+            "en-SG",
+            "en-TT",
+            "en-US",
+            "en-ZA",
+            "en-ZW"
+          ]
+        }
+      }
+    },
+    {
+      "id": 2,
+      "attributes": {
+        "appVersion": {
+          "min": "7.118.0"
+        },
+        "atb": {
+          "value": "v430-2"
+        },
+        "daysSinceInstalled": {
+          "min": 0,
+          "max": 3
+        },
+        "emailEnabled": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "en-AU",
+            "en-BZ",
+            "en-CA",
+            "en-cb",
+            "en-GB",
+            "en-IE",
+            "en-IN",
+            "en-JM",
+            "en-MT",
+            "en-MY",
+            "en-NZ",
+            "en-PH",
+            "en-SG",
+            "en-TT",
+            "en-US",
+            "en-ZA",
+            "en-ZW"
+          ]
+        }
+      }
+    },
+    {
+      "id": 3,
+      "attributes": {
+        "appVersion": {
+          "min": "7.118.0"
+        },
+        "atb": {
+          "value": "v430-3"
+        },
+        "daysSinceInstalled": {
+          "min": 0,
+          "max": 3
+        },
+        "emailEnabled": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "en-AU",
+            "en-BZ",
+            "en-CA",
+            "en-cb",
+            "en-GB",
+            "en-IE",
+            "en-IN",
+            "en-JM",
+            "en-MT",
+            "en-MY",
+            "en-NZ",
+            "en-PH",
+            "en-SG",
+            "en-TT",
+            "en-US",
+            "en-ZA",
+            "en-ZW"
+          ]
+        }
+      }
+    },
+    {
+      "id": 4,
+      "attributes": {
+        "appVersion": {
+          "min": "7.118.0"
+        },
+        "atb": {
+          "value": "v430-4"
+        },
+        "daysSinceInstalled": {
+          "min": 0,
+          "max": 3
+        },
+        "emailEnabled": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "en-AU",
+            "en-BZ",
+            "en-CA",
+            "en-cb",
+            "en-GB",
+            "en-IE",
+            "en-IN",
+            "en-JM",
+            "en-MT",
+            "en-MY",
+            "en-NZ",
+            "en-PH",
+            "en-SG",
+            "en-TT",
+            "en-US",
+            "en-ZA",
+            "en-ZW"
+          ]
+        }
+      }
+    },
+    {
+      "id": 5,
+      "attributes": {
+        "appVersion": {
+          "min": "7.118.0"
+        },
+        "atb": {
+          "value": "v430-5"
+        },
+        "daysSinceInstalled": {
+          "min": 0,
+          "max": 3
+        },
+        "emailEnabled": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "en-AU",
+            "en-BZ",
+            "en-CA",
+            "en-cb",
+            "en-GB",
+            "en-IE",
+            "en-IN",
+            "en-JM",
+            "en-MT",
+            "en-MY",
+            "en-NZ",
+            "en-PH",
+            "en-SG",
+            "en-TT",
+            "en-US",
+            "en-ZA",
+            "en-ZW"
+          ]
+        }
+      }
+    },
+    {
+      "id": 6,
+      "attributes": {
+        "appVersion": {
+          "min": "7.118.0"
+        },
+        "atb": {
+          "value": "v430-6"
+        },
+        "daysSinceInstalled": {
+          "min": 0,
+          "max": 3
+        },
+        "emailEnabled": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "en-AU",
+            "en-BZ",
+            "en-CA",
+            "en-cb",
+            "en-GB",
+            "en-IE",
+            "en-IN",
+            "en-JM",
+            "en-MT",
+            "en-MY",
+            "en-NZ",
+            "en-PH",
+            "en-SG",
+            "en-TT",
+            "en-US",
+            "en-ZA",
+            "en-ZW"
+          ]
+        }
+      }
+    },
+    {
+      "id": 7,
+      "attributes": {
+        "appVersion": {
+          "min": "7.118.0"
+        },
+        "atb": {
+          "value": "v430-7"
+        },
+        "daysSinceInstalled": {
+          "min": 0,
+          "max": 3
+        },
+        "emailEnabled": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "en-AU",
+            "en-BZ",
+            "en-CA",
+            "en-cb",
+            "en-GB",
+            "en-IE",
+            "en-IN",
+            "en-JM",
+            "en-MT",
+            "en-MY",
+            "en-NZ",
+            "en-PH",
+            "en-SG",
+            "en-TT",
+            "en-US",
+            "en-ZA",
+            "en-ZW"
+          ]
+        }
+      }
+    },
+    {
+      "id": 8,
+      "attributes": {
+        "expVariant": {
+          "value": "ru"
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
**Task:** https://app.asana.com/0/0/1207195238557218/f
**Description:** Adds Email Campaign 

Targeting Rules:
- App version >= 7.118.0
- 1 week of new installs: ATB week=430 (assuming a May 15th start)
- Days since installed <= 3
- Email disabled
- English only: device local = en_*
- Exclude re-installers: experiment variant not equal to ru

**Testing Instructions:**
1. Update `RemoteMessageRequest.swift` debug URL to point to  https://staticcdn.duckduckgo.com/remotemessaging/config/staging/pre/ios-config.json
2. Launch the app on a simulator with an existing build and confirm the message does not appear
3. To test that returning users are excluded modify `RemoteMessaging.swift` and add this line `statisticsStore.atb = "v430-1"`  to `fetchAndProcess` (before the `remoteMessagingConfigMatcher` call to set the atb to match one of the config matching atbs)
![image](https://github.com/duckduckgo/remote-messaging-config/assets/91189922/16e04038-cb18-4856-aa7d-096c41da1940)
4. Delete the app on simulator and re-install. 
5. Complete onboarding and re-launch the app
6. Confirm the message does not appear 
7. Launch either another simulator that doesn't already have the DDG app installed (or Erase all Contents and Settings on the current simulator)
8. Install the app and complete onboarding
9. Relaunch the app and confirm that this time the message does appear 

