### PR TITLE
Restore the iOS Privacy Pro survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,17 +1,20 @@
 {
-  "version": 30,
+  "version": 32,
   "messages": [
     {
-      "id": "ddg_ios_survey_1",
+      "id": "ios_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "RemoteMessageAnnouncement",
+        "titleText": "Tell Us Your Thoughts on Privacy Pro",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
-          "type": "survey_url",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240200?list=2"
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
         }
       },
       "matchingRules": [
@@ -23,12 +26,20 @@
     {
       "id": 1,
       "attributes": {
-        "daysSinceInstalled": {
-          "min": 5,
-          "max": 8
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": "active"
         },
         "appVersion": {
-          "min": "7.106.0.4"
+          "min": "7.124.0.1"
         }
       }
     }


### PR DESCRIPTION
**Task:** https://app.asana.com/0/0/1207624570799167/f

This PR restores the iOS Privacy Pro survey, which was accidentally removed in https://github.com/duckduckgo/remote-messaging-config/pull/68.

These changes were already reviewed and approved in https://github.com/duckduckgo/remote-messaging-config/pull/58, see that PR for testing steps. This PR is identical to that one, except I have removed `atb` and `vpn_first_used` parameters at the request of the Privacy team.