### PR TITLE
iOS Privacy Pro exit survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -39,6 +39,9 @@
       },
       "matchingRules": [
         1
+      ],
+      "exclusionRules": [
+        3
       ]
     },
     {
@@ -54,7 +57,7 @@
         }
       },
       "matchingRules": [
-        3
+        4
       ]
     }
   ],
@@ -98,6 +101,16 @@
     },
     {
       "id": 3,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": [
+            "ios_privacy_pro_cancellation_survey_1"
+          ]
+        }
+      }
+    },
+    {
+      "id": 4,
       "attributes": {
         "osApi": {
           "min": "14.0.0",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -2,7 +2,7 @@
   "version": 34,
   "messages": [
     {
-      "id": "ios_privacy_pro_cancellation_survey_1",
+      "id": "ios_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Why You Left Privacy Pro",
@@ -104,7 +104,7 @@
       "attributes": {
         "interactedWithMessage": {
           "value": [
-            "ios_privacy_pro_cancellation_survey_1"
+            "ios_privacy_pro_exit_survey_1"
           ]
         }
       }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -18,7 +18,7 @@
         }
       },
       "matchingRules": [
-        1
+        2
       ]
     },
     {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,6 +1,26 @@
 {
-  "version": 32,
+  "version": 33,
   "messages": [
+    {
+      "id": "ios_privacy_pro_cancellation_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Please Let Us Know Why You're Leaving Privacy Pro",
+        "descriptionText": "By completing our brief survey, you will help us improve the Privacy Pro experience for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        1
+      ]
+    },
     {
       "id": "ios_privacy_pro_subscriber_survey_1",
       "content": {
@@ -37,6 +57,23 @@
         },
         "pproSubscriptionStatus": {
           "value": "active"
+        },
+        "appVersion": {
+          "min": "7.124.0.1"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": "expiring"
         },
         "appVersion": {
           "min": "7.124.0.1"

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -5,8 +5,8 @@
       "id": "ios_privacy_pro_cancellation_survey_1",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Please Let Us Know Why You're Leaving Privacy Pro",
-        "descriptionText": "By completing our brief survey, you will help us improve the Privacy Pro experience for all subscribers.",
+        "titleText": "Tell Us Why You Left Privacy Pro",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {


### PR DESCRIPTION
**Task:** https://app.asana.com/0/1207619243206445/1207636661001863/f

This PR adds the Privacy Pro exit survey.

It is set up to hide the New Subscriber survey from users who have interacted with the Exit survey, using the `exclusionRules` feature.

**Testing steps:**

1. First, set up the app to use this RMF manifest, and check that you get no messages when signed out of Privacy Pro
2. Sign into an active account that has been in use for 14+ days and check that you get the New Subscriber survey - do not interact with it though, since we later want to check that it is hidden when you interact with the Exit survey
3. Override your account to simulate it being in the cancelled state, and check that you get the Exit survey instead - to do this, you can modify `RemoteMessagingClient.swift` around lines 186-197 to force `privacyProIsExpiring` to true even if your account is active
4. Open or dismiss the Exit survey, and then check that you do **not** get the New Subscriber survey the next time RMF refreshes