### PR TITLE
iOS 14 deprecation warning

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -63,8 +63,8 @@
       "id": 2,
       "attributes": {
         "osApi": {
-          "min": "14",
-          "max": "14",
+          "min": "15",
+          "max": "15",
           "fallback": true
         }
       }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -66,6 +66,9 @@
           "min": "15",
           "max": "15",
           "fallback": true
+        },
+        "appVersion": {
+          "min": "7.106.0.4"
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -63,8 +63,8 @@
       "id": 2,
       "attributes": {
         "osApi": {
-          "min": "15",
-          "max": "15",
+          "min": "15.0.0",
+          "max": "15.9.9",
           "fallback": true
         },
         "appVersion": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -26,7 +26,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "iOS Update Recommended",
-        "descriptionText": "Support for iOS 14 is ending soon. Update to iOS 15 or newer before July 1, 2024 to keep getting the latest browser updates and improvements.",
+        "descriptionText": "Support for iOS 14 is ending soon. Update to iOS 15 or newer before July 8, 2024 to keep getting the latest browser updates and improvements.",
         "primaryActionText": "How To Update iOS",
         "primaryAction": {
           "type": "url",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -63,8 +63,8 @@
       "id": 2,
       "attributes": {
         "osApi": {
-          "min": "15.0.0",
-          "max": "15.9.9",
+          "min": "14.0.0",
+          "max": "14.9.9",
           "fallback": true
         },
         "appVersion": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -64,8 +64,7 @@
       "attributes": {
         "osApi": {
           "min": "14.0.0",
-          "max": "14.9.9",
-          "fallback": true
+          "max": "14.9.9"
         },
         "appVersion": {
           "min": "7.106.0.4"

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 32,
+  "version": 33,
   "messages": [
     {
       "id": "ios_privacy_pro_subscriber_survey_1",
@@ -19,6 +19,22 @@
       },
       "matchingRules": [
         1
+      ]
+    },
+    {
+      "id": "ios_14_deprecation_warning",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "iOS Update Recommended",
+        "descriptionText": "Support for iOS 14 is ending soon. Update to iOS 15 or newer before July 1, 2024 to keep getting the latest browser updates and improvements.",
+        "primaryActionText": "How To Update iOS",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://support.apple.com/guide/iphone/update-ios-iph3e504502/14.0/ios/14.0"
+        }
+      },
+      "matchingRules": [
+        2
       ]
     }
   ],
@@ -40,6 +56,16 @@
         },
         "appVersion": {
           "min": "7.124.0.1"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "attributes": {
+        "osApi": {
+          "min": "14",
+          "max": "14",
+          "fallback": true
         }
       }
     }


### PR DESCRIPTION
**Task:** https://app.asana.com/0/1207619243206445/1207650299373621/f

This PR adds the deprecation warning for iOS 14 users.

**Testing steps:**

Xcode 15 does not support the iOS 14 SDK. If you'd like to test with Xcode 15, please override the OS version being passed to RMF locally before testing.

1. Update the app to point to the [staging URL](https://staticcdn.duckduckgo.com/remotemessaging/config/staging/pre/ios-config.json)
1. Run an iOS 14 device and make sure the message appears
2. Run an iOS 15 device and make sure the message does not appear