### PR TITLE
Add config files for macOS and Windows

### DIFF
--- a/.github/workflows/macos-PR-to-staging.yml
+++ b/.github/workflows/macos-PR-to-staging.yml
@@ -1,0 +1,32 @@
+name: PR to staging (macOS)
+
+on: 
+  push:
+      paths:
+      - 'live/macos-config/macos-config.json'
+  pull_request:
+    types:
+      - opened
+    paths:
+      - 'live/macos-config/macos-config.json'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311
+      if: github.event_name == 'push'
+      with:
+        args: --acl public-read --follow-symlinks
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SOURCE_DIR: 'live/macos-config'
+        DEST_DIR: 'remotemessaging/config/staging/pre'
+    - uses: github-actions-up-and-running/pr-comment@f1f8ab2bf00dce6880a369ce08758a60c61d6c0b
+      if: github.event.action == 'opened'
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        message: 'Your PR is hosted at https://staticcdn.duckduckgo.com/remotemessaging/config/staging/pre/macos-config.json'

--- a/.github/workflows/macos-build-and-publish.yml
+++ b/.github/workflows/macos-build-and-publish.yml
@@ -1,0 +1,34 @@
+name: Build and Publish (macOS)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'live/macos-config/macos-config.json'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311
+      with:
+        args: --acl public-read --follow-symlinks
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1'
+        SOURCE_DIR: 'live/macos-config'
+        DEST_DIR: 'remotemessaging/config/v1'
+    - uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311
+      with:
+        args: --acl public-read --follow-symlinks
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1'
+        SOURCE_DIR: 'live/macos-config'
+        DEST_DIR: 'remotemessaging/config/staging'

--- a/.github/workflows/windows-PR-to-staging.yml
+++ b/.github/workflows/windows-PR-to-staging.yml
@@ -1,0 +1,32 @@
+name: PR to staging (Windows)
+
+on: 
+  push:
+      paths:
+      - 'live/windows-config/windows-config.json'
+  pull_request:
+    types:
+      - opened
+    paths:
+      - 'live/windows-config/windows-config.json'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311
+      if: github.event_name == 'push'
+      with:
+        args: --acl public-read --follow-symlinks
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SOURCE_DIR: 'live/windows-config'
+        DEST_DIR: 'remotemessaging/config/staging/pre'
+    - uses: github-actions-up-and-running/pr-comment@f1f8ab2bf00dce6880a369ce08758a60c61d6c0b
+      if: github.event.action == 'opened'
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        message: 'Your PR is hosted at https://staticcdn.duckduckgo.com/remotemessaging/config/staging/pre/windows-config.json'

--- a/.github/workflows/windows-build-and-publish.yml
+++ b/.github/workflows/windows-build-and-publish.yml
@@ -1,0 +1,34 @@
+name: Build and Publish (macOS)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'live/macos-config/macos-config.json'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311
+      with:
+        args: --acl public-read --follow-symlinks
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1'
+        SOURCE_DIR: 'live/macos-config'
+        DEST_DIR: 'remotemessaging/config/v1'
+    - uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311
+      with:
+        args: --acl public-read --follow-symlinks
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1'
+        SOURCE_DIR: 'live/macos-config'
+        DEST_DIR: 'remotemessaging/config/staging'

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,0 +1,5 @@
+{
+    "version": 0,
+    "messages": [],
+    "rules": []
+}

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,0 +1,5 @@
+{
+    "version": 0,
+    "messages": [],
+    "rules": []
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207587223508406/f

Description:
This change adds empty config files for macOS and Windows and workflows to publish them to production and staging
(copied over from existing iOS workflows and adjusted as needed).