### PR TITLE
New July Privacy Pro promotion for new installs

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -85,7 +85,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Level up your privacy!",
-        "descriptionText": "Boost your privacy with our fast & secure VPN + 2 more new protections.",
+        "descriptionText": "Boost your privacy with our fast and secure VPN, plus two more premium protections.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Get Privacy Pro",
         "primaryAction": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -61,26 +61,6 @@
       ]
     },
     {
-      "id": "ddg_ios_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "RemoteMessageAnnouncement",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240200?list=3",
-          "additionalParameters": {
-            "queryParams": "atb;var;ddgv;mo;osv"
-          }
-        }
-      },
-      "matchingRules": [
-        5
-      ]
-    },
-    {
       "id": "funnel_pro_ios_rmf_onboarding_levelup",
       "content": {
         "messageType": "big_single_action",
@@ -156,18 +136,6 @@
         },
         "appVersion": {
           "min": "7.106.0.4"
-        }
-      }
-    },
-    {
-      "id": 5,
-      "attributes": {
-        "daysSinceInstalled": {
-          "min": 5,
-          "max": 8
-        },
-        "appVersion": {
-          "min": "7.124.0.1"
         }
       }
     },

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -65,7 +65,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Level up your privacy!",
-        "descriptionText": "Boost your privacy with our fast and secure VPN, plus two more premium protections.",
+        "descriptionText": "Boost privacy with our fast & secure VPN + 2 more premium protections.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Get Privacy Pro",
         "primaryAction": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 36,
+  "version": 37,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -79,6 +79,24 @@
       "matchingRules": [
         5
       ]
+    },
+    {
+      "id": "funnel_pro_ios_rmf_onboarding_levelup",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Level up your privacy!",
+        "descriptionText": "Boost your privacy with our fast & secure VPN + 2 more new protections.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Get Privacy Pro",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/pro?origin=funnel_pro_iosrmf_onboarding_levelup"
+        }
+      },
+      "matchingRules": [
+        6
+      ],
+      "exclusionRules": []
     }
   ],
   "rules": [
@@ -147,6 +165,29 @@
         "daysSinceInstalled": {
           "min": 5,
           "max": 8
+        },
+        "appVersion": {
+          "min": "7.124.0.1"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "attributes": {
+        "pproEligible": {
+          "value": true
+        },
+        "pproSubscriber": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "en-US"
+          ]
+        },
+        "daysSinceInstalled": {
+          "min": 2,
+          "max": 10
         },
         "appVersion": {
           "min": "7.124.0.1"

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 37,
+  "version": 38,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",


### PR DESCRIPTION
Task: https://app.asana.com/0/1207619243206445/1207546055898910/f

This PR enables a Privacy Pro promotion for new installs 

**Testing Steps:**
1. Update RemoteMessagingClient to use the staging URL from the comments below as the debug URL
2. Drag in BSK so that local code changes can be made. In `RemoteMessagingConfigProcessor.swift` update `shouldProcessConfig` to always return true
3. Ensure the device you are testing on has the locale region set to the US
4. Sign out of Privacy Pro (if already signed in)
5. Test that the install date range is working by overriding daysSinceInstall value (search for line `case let matchingAttribute as DaysSinceInstalledMatchingAttribute` in `UserAttributeMatcher.swift`) to test the range. Try it with 0, 4, and 12, and check that the message only appears for the 4 case
6. Sign in to Privacy Pro and confirm the message no longer appears
7. Finally, sign back out and confirm clicking the link takes you to the Privacy Pro sign up flow