### PR TITLE
Add Privacy Pro surveys to macOS

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -44,9 +44,6 @@
     {
       "id": 1,
       "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
         "pproPurchasePlatform": {
           "value": ["apple", "stripe"]
         },
@@ -61,9 +58,6 @@
     {
       "id": 2,
       "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
         "pproDaysSinceSubscribed": {
           "min": 14
         },

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,106 @@
 {
-    "version": 0,
-    "messages": [],
-    "rules": []
+  "version": 1,
+  "messages": [
+    {
+      "id": "macos_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Why You Left Privacy Pro",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [1],
+      "exclusionRules": [4]
+    },
+    {
+      "id": "macos_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Your Thoughts on Privacy Pro",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [2],
+      "exclusionRules": [3, 5]
+    }
+  ],
+  "rules": [
+    {
+      "id": 1,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": "expiring"
+        },
+        "appVersion": {
+          "min": "1.99.0"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": "active"
+        },
+        "appVersion": {
+          "min": "1.99.0"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": ["ios_privacy_pro_exit_survey_1"]
+        }
+      }
+    },
+    {
+      "id": 4,
+      "attributes": {
+        "interactedWithDeprecatedMacRemoteMessage": {
+          "value": ["privacy_pro_exit_survey_1"]
+        }
+      }
+    },
+    {
+      "id": 5,
+      "attributes": {
+        "interactedWithDeprecatedMacRemoteMessage": {
+          "value": ["privacy_pro_survey_1"]
+        }
+      }
+    }
+  ]
 }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -54,7 +54,7 @@
           "value": ["expiring"]
         },
         "appVersion": {
-          "min": "1.99.0"
+          "min": "1.101.0"
         }
       }
     },
@@ -74,7 +74,7 @@
           "value": ["active"]
         },
         "appVersion": {
-          "min": "1.99.0"
+          "min": "1.101.0"
         }
       }
     },
@@ -82,7 +82,7 @@
       "id": 3,
       "attributes": {
         "interactedWithMessage": {
-          "value": ["ios_privacy_pro_exit_survey_1"]
+          "value": ["macos_privacy_pro_exit_survey_1"]
         }
       }
     },

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -44,11 +44,14 @@
     {
       "id": 1,
       "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
         "pproPurchasePlatform": {
           "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
-          "value": "expiring"
+          "value": ["expiring"]
         },
         "appVersion": {
           "min": "1.99.0"
@@ -58,6 +61,9 @@
     {
       "id": 2,
       "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
         "pproDaysSinceSubscribed": {
           "min": 14
         },
@@ -65,7 +71,7 @@
           "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
-          "value": "active"
+          "value": ["active"]
         },
         "appVersion": {
           "min": "1.99.0"


### PR DESCRIPTION
**Task:** https://app.asana.com/0/1207619243206445/1208041703530761/f

This PR adds the Privacy Pro surveys to the macOS app.

**How to test the subscriber survey:**

1. Update the client to use the staging URL below
2. Sign into a Privacy Pro account, and, if necessary, hardcode the `privacyProDaysSinceSubscribed` initializer value in `RemoteMessagingConfigMatcherProvider` to be 14 or above
3. Update the `shouldProcessConfig` func in BSK to always return true, for testing multiple cases
4. Test that when you relaunch the app, the subscriber survey appears
5. Now hardcode the `privacyProDaysSinceSubscribed` value to be below 14
6. Relaunch the app and verify that the survey is gone

**How to test the exit survey:**

1. Now we need to test an expiring account; update `RemoteMessagingConfigMatcherProvider` line ~94 to set `isPrivacyProSubscriptionExpiring` to true and all other booleans to false
2. Relaunch the app and verify that the exit survey shows up

---

![CleanShot 2024-08-12 at 21 06 12@2x](https://github.com/user-attachments/assets/b0b2da4b-053b-40f5-84b8-4d3e93b19049)
![CleanShot 2024-08-12 at 20 51 06@2x](https://github.com/user-attachments/assets/0e991bbf-dc65-429e-9013-5d4974c83341)
