### PR TITLE
iOS Privacy Pro survey update

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -75,7 +75,7 @@
           "value": ["apple"]
         },
         "pproSubscriptionStatus": {
-          "value": "active"
+          "value": ["active"]
         },
         "appVersion": {
           "min": "7.124.0.1"
@@ -92,7 +92,7 @@
           "value": ["apple"]
         },
         "pproSubscriptionStatus": {
-          "value": "expiring"
+          "value": ["expiring"]
         },
         "appVersion": {
           "min": "7.124.0.1"

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 39,
+  "version": 40,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -78,7 +78,7 @@
           "value": ["active"]
         },
         "appVersion": {
-          "min": "7.124.0.1"
+          "min": "7.128.0.1"
         }
       }
     },
@@ -95,7 +95,7 @@
           "value": ["expiring"]
         },
         "appVersion": {
-          "min": "7.124.0.1"
+          "min": "7.128.0.1"
         }
       }
     },


### PR DESCRIPTION
Task: https://app.asana.com/0/1199333091098016/1207959841728982/f

This PR updates the Privacy Pro survey to match recent attribute format updates.

**How to test:**

This survey was previously tested in https://github.com/duckduckgo/remote-messaging-config/pull/58, see that PR for testing steps. Everything about the survey is the same, it's just that we changed the status attribute from a string to an array of strings.