### PR TITLE
New Privacy pro promo for installs between 1 and 2 days

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 39,
+  "version": 40,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -59,6 +59,24 @@
       "matchingRules": [
         4
       ]
+    },
+    {
+      "id": "funnel_pro_iosrmf_onboarding_levelup",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Level up your privacy!",
+        "descriptionText": "Boost your privacy with our fast & secure VPN + 2 more new protections.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Get Privacy Pro",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/pro?origin=funnel_pro_iosrmf_onboarding_levelup"
+        }
+      },
+      "matchingRules": [
+        5
+      ],
+      "exclusionRules": []
     }
   ],
   "rules": [
@@ -118,6 +136,29 @@
         },
         "appVersion": {
           "min": "7.106.0.4"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "attributes": {
+        "pproEligible": {
+          "value": true
+        },
+        "pproSubscriber": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "en-US"
+          ]
+        },
+        "daysSinceInstalled": {
+          "min": 1,
+          "max": 2
+        },
+        "appVersion": {
+          "min": "7.124.0.1"
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 40,
+  "version": 41,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",


### PR DESCRIPTION
Task: https://app.asana.com/0/1207619243206445/1207957884250329/f

This PR is a repeat of [July promo](https://app.asana.com/0/1207619243206445/1207546055898910/f), except targets users 1-2 days after install

Test steps:
See [previous PR](https://github.com/duckduckgo/remote-messaging-config/pull/85) for test steps, except with the valid install date range changed



