### PR TITLE
Remove the iOS 14 deprecation message

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 41,
+  "version": 42,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -42,22 +42,6 @@
       ],
       "exclusionRules": [
         3
-      ]
-    },
-    {
-      "id": "ios_14_deprecation_warning",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "iOS Update Recommended",
-        "descriptionText": "Support for iOS 14 is ending soon. Update to iOS 15 or newer before July 8, 2024 to keep getting the latest browser updates and improvements.",
-        "primaryActionText": "How To Update iOS",
-        "primaryAction": {
-          "type": "url",
-          "value": "https://support.apple.com/guide/iphone/update-ios-iph3e504502/14.0/ios/14.0"
-        }
-      },
-      "matchingRules": [
-        4
       ]
     },
     {
@@ -124,18 +108,6 @@
           "value": [
             "ios_privacy_pro_exit_survey_1"
           ]
-        }
-      }
-    },
-    {
-      "id": 4,
-      "attributes": {
-        "osApi": {
-          "min": "14.0.0",
-          "max": "14.9.9"
-        },
-        "appVersion": {
-          "min": "7.106.0.4"
         }
       }
     },


### PR DESCRIPTION
Task: https://app.asana.com/0/1207619243206445/1207650295717899/f

This PR removes the iOS 14 deprecation message.

**How to test:**
* Check that the message is correctly removed from the manifest and that the rule that was removed is not being used by any other message