### PR TITLE
iOS survey August 2024

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 42,
+  "version": 43,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -61,6 +61,26 @@
         5
       ],
       "exclusionRules": []
+    },
+    {
+      "id": "ddg_ios_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help us improve the app!",
+        "descriptionText": "Take our short anonymous survey and share your feedback.",
+        "placeholder": "RemoteMessageAnnouncement",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240200?list=3",
+          "additionalParameters": {
+            "queryParams": "atb;var;ddgv;mo;osv"
+          }
+        }
+      },
+      "matchingRules": [
+        4
+      ]
     }
   ],
   "rules": [
@@ -111,6 +131,18 @@
         }
       }
     },
+    {
+      "id": 4,
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 5,
+          "max": 8
+        },
+        "appVersion": {
+          "min": "7.124.0.1"
+        }
+      }
+    }
     {
       "id": 5,
       "attributes": {


### PR DESCRIPTION
Task: https://app.asana.com/0/1193060753475688/1208031021631165/f

This PR adds the August 2024 iOS survey. This PR is the same as previous surveys such as https://github.com/duckduckgo/remote-messaging-config/pull/77.

**Testing instructions:**

1. Update `RemoteMessageRequest` to include the sample URL attached in the comments below
2. Update `shouldProcessConfig` to always return true
3. Now we need to test that the install date range is working. We have no method in the Debug menu for overriding this so for now you'll need to use a local copy of BSK and search for the line `case let matchingAttribute as DaysSinceInstalledMatchingAttribute`
4. Underneath the line mentioned above, you can override `daysSinceInstall` value to check the range. Try it with `0`, `5`, and `10`, and check that the message only appears for the `5` case
5. Finally, set the value back to one that matches the range, and check that opening the link correctly opens the survey