### PR TITLE
Remove iOS August 2024 survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -61,26 +61,6 @@
         5
       ],
       "exclusionRules": []
-    },
-    {
-      "id": "ddg_ios_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "RemoteMessageAnnouncement",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240200?list=3",
-          "additionalParameters": {
-            "queryParams": "atb;var;ddgv;mo;osv"
-          }
-        }
-      },
-      "matchingRules": [
-        4
-      ]
     }
   ],
   "rules": [
@@ -128,18 +108,6 @@
           "value": [
             "ios_privacy_pro_exit_survey_1"
           ]
-        }
-      }
-    },
-    {
-      "id": 4,
-      "attributes": {
-        "daysSinceInstalled": {
-          "min": 5,
-          "max": 8
-        },
-        "appVersion": {
-          "min": "7.124.0.1"
         }
       }
     },

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 43,
+  "version": 44,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",


### PR DESCRIPTION
Task: https://app.asana.com/0/0/1208085877011913/f

This PR removes the permanent survey for August.

For testing this, double check that the removal looks correct. See the [previous PR](https://github.com/duckduckgo/remote-messaging-config/pull/83/files) for an example.