### PR TITLE
Add quarterly satisfaction survey (and pausing other active surveys)

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -75,6 +75,9 @@
     },
     {
       "id": 4,
+      "targetPercentile": {
+        "before": 1.0
+      },
       "attributes": {
         "locale": {
           "value": [

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -76,7 +76,7 @@
     {
       "id": 4,
       "targetPercentile": {
-        "before": 1.0
+        "before": 0.25
       },
       "attributes": {
         "locale": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 45,
+  "version": 46,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -22,50 +22,30 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_1",
+      "id": "ios_quarterly_satisfaction_survey_q4_2024",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "titleText": "Help us improve the app!",
+        "descriptionText": "Take our short anonymous survey and share your feedback.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240903?list=2",
           "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+            "queryParams": "var;delta;osv;ddgv"
           }
         }
       },
       "matchingRules": [
-        1
+        4
       ],
       "exclusionRules": [
-        3
+        2, 3
       ]
     }
   ],
   "rules": [
-    {
-      "id": 1,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproDaysSinceSubscribed": {
-          "min": 14
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["active"]
-        },
-        "appVersion": {
-          "min": "7.128.0.1"
-        }
-      }
-    },
     {
       "id": 2,
       "attributes": {
@@ -90,6 +70,22 @@
           "value": [
             "ios_privacy_pro_exit_survey_1"
           ]
+        }
+      }
+    },
+    {
+      "id": 4,
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        },
+        "appVersion": {
+          "min": "7.123.0.0"
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -27,7 +27,7 @@
         "messageType": "big_single_action",
         "titleText": "Help us improve the app!",
         "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "PrivacyShield",
+        "placeholder": "RemoteMessageAnnouncement",
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1208267825401257/f

Description : Adding quarterly satisfactory survey and temporarily removing `ios_privacy_pro_subscriber_survey_1`

Steps to test:
- confirm the version number has been incremented
- confirm the only other active survey remaining is `ios_privacy_pro_exit_survey_1` and that the rules it references are still in place
- confirm new message matches requirements from the description of this task https://app.asana.com/0/1207619243206445/1208265082488130/f
- Note that the targetPercentile is currently set to `1` as the staging config is being used by the Ship Review build, I’ll be updating it to `0.25` before this goes live
- To test update the debug URL in `RemoteMessagingClient.swift` to  https://staticcdn.duckduckgo.com/remotemessaging/config/staging/pre/ios-config.json and confirm the RMF message appears (assuming you meet the rule requirements 🙂). 
- Click the survey link and confirm the correct parameters are appended `var;delta;osv;ddgv`