### PR TITLE
Update macOS Permanent survey last day to 14

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -227,7 +227,7 @@
         },
         "daysSinceInstalled": {
           "min": 5,
-          "max": 8
+          "max": 14
         },
         "locale": {
           "value": [

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 4,
   "messages": [
     {
       "id": "macos_privacy_pro_app_store_exit_survey_1",


### PR DESCRIPTION
https://app.asana.com/0/1206488453854252/1208492802071664/f

This PR updates the macOS day 5 survey, increasing the last day from 8 to 14. Note to @samsymons  - I’ve not yet familiar with RMF, so it’s worth checking the associated Asana task to ensure I made the right changes. Thanks!

**How to test:**

Before you start, you'll need to be using English as your device's language - this survey targets en-US, en-CA, en-GB, and en-AU.

1. Update `RemoteMessagingClient.swift`'s debug URL to use the [macOS staging URL](https://staticcdn.duckduckgo.com/remotemessaging/config/staging/macos-config.json)
2. Next, we need to simulate having installed the app between 5 and 14 days ago; to do this, you'll need to drop a local copy of BSK onto your project so that you can edit it, open UserAttributeMatcher.swift, then look for the line case let matchingAttribute as DaysSinceInstalledMatchingAttribute. Edit the logic inside this case to change the value of daysSinceInstall to between 5-14. _(Note: we have an option for changing the install date in the debug menu, but I think it affects a key that is separate from the statistics store - need to look into it further)_
3. Launch the app, open the Debug menu's Remote Messaging Config section, select "Reset Remote Messages", then select "Refresh Messages" in the same Debug menu
4. Open a new tab and the message should appear - click the survey URL and make sure it opens as expected, and that parameters look sensible