### PR TITLE
Add permanent iOS survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -115,13 +115,13 @@
     },
     {
       "id": 4,
+      "targetPercentile": {
+        "before": 0.3
+      },
       "attributes": {
         "daysSinceInstalled": {
           "min": 5,
           "max": 8
-        },
-        "targetPercentile": {
-          "before": 0.3
         },
         "appVersion": {
           "min": "7.124.0.1"

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 47,
+  "version": 48,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -42,6 +42,26 @@
       ],
       "exclusionRules": [
         3
+      ]
+    },
+    {
+      "id": "ddg_ios_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help us improve the app!",
+        "descriptionText": "Take our short anonymous survey and share your feedback.",
+        "placeholder": "Announce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240200?list=3",
+          "additionalParameters": {
+            "queryParams": "atb;var;ddgv;mo;osv"
+          }
+        }
+      },
+      "matchingRules": [
+        4
       ]
     }
   ],
@@ -90,6 +110,21 @@
           "value": [
             "ios_privacy_pro_exit_survey_1"
           ]
+        }
+      }
+    },
+    {
+      "id": 4,
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 5,
+          "max": 8
+        },
+        "targetPercentile": {
+          "before": 0.3
+        },
+        "appVersion": {
+          "min": "7.124.0.1"
         }
       }
     }


### PR DESCRIPTION
Task: https://app.asana.com/0/1207619243206445/1208454188907378/f

This PR adds the permanent iOS survey. This PR is very similar to previous surveys such as https://github.com/duckduckgo/remote-messaging-config/pull/95, except this survey adds a `targetPercentile` of 0.3.

**Testing instructions:**

**Note:** This survey has a 30% chance of appearing. If it doesn't appear, you could delete and reinstall the app to get a new percentile roll, or you may hardcode `RemoteMessagingPercentileUserDefaultsStore` to give you a valid value.

1. Update `RemoteMessageRequest` to include the sample URL attached in the comments below
2. Update `shouldProcessConfig` to always return true
3. Now we need to test that the install date range is working. We have no method in the Debug menu for overriding this so for now you'll need to use a local copy of BSK and search for the line `case let matchingAttribute as DaysSinceInstalledMatchingAttribute`
4. Underneath the line mentioned above, you can override `daysSinceInstall` value to check the range. Try it with `0`, `5`, and `10`, and check that the message only appears for the `5` case
5. Finally, set the value back to one that matches the range, and check that opening the link correctly opens the survey