### PR TITLE
Add automatic update failed message

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "messages": [
     {
       "id": "macos_privacy_pro_app_store_exit_survey_1",
@@ -94,6 +94,16 @@
         }
       },
       "matchingRules": [9]
+    },
+    {
+      "id": "macos_switch_to_manual_updates",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Automatic Update Failed",
+        "descriptionText": "To get the latest version of DuckDuckGo  \n1\\. Go to **Settings > About**  \n2\\. Select **Check for updates but let me choose to install them**  \n3\\. Click **Restart To Update**",
+        "placeholder": "CriticalUpdate"
+      },
+      "matchingRules": [10]
     }
   ],
   "rules": [
@@ -236,6 +246,18 @@
             "en-GB",
             "en-AU"
           ]
+        }
+      }
+    },
+    {
+      "id": 10,
+      "attributes": {
+        "appVersion": {
+          "min": "1.99.0",
+          "max": "1.102.0"
+        },
+        "installedMacAppStore": {
+          "value": false
         }
       }
     }


### PR DESCRIPTION
https://app.asana.com/0/1207619243206445/1208340098560916/f

This PR adds message for users who are stuck on specific versions due to the automatic updates not working properly.

How to test:

1. Update RemoteMessagingClient.swift's debug URL to use the staging url: https://staticcdn.duckduckgo.com/remotemessaging/config/staging/macos-config.json
2. Set the app version to 1.99.0
3. Open a new tab and the message explaining the switching to the manual updates should appear
5. Set the app version to 1.103.0 
6. Verify the message won't show