### PR TITLE
Migrate existing Windows surveys to RMF

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -50,29 +50,6 @@
         7,
         8
       ]
-    },
-    {
-      "id": "windows_permanent_survey",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help Us Improve",
-        "descriptionText": "Take our short survey and help us build the best browser.",
-        "placeholder": "Announce",
-        "primaryActionText": "Share Your Thoughts",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/231005?list=1",
-          "additionalParameters": {
-            "queryParams": "wv;atb;ddgv;sts"
-          }
-        }
-      },
-      "matchingRules": [
-        9
-      ],
-      "exclusionRules": [
-        10
-      ]
     }
   ],
   "rules": [
@@ -153,36 +130,6 @@
         "interactedWithDeprecatedWindowsSurvey": {
           "value": [
             "new-subscription-survey.dismissed"
-          ]
-        }
-      }
-    },
-    {
-      "id": 9,
-      "attributes": {
-        "appVersion": {
-          "min": <TBD>
-        },
-        "daysSinceInstalled": {
-          "min": 5,
-          "max": 14
-        },
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
-          ]
-        }
-      }
-    },
-    {
-      "id": 10,
-      "attributes": {
-        "interactedWithDeprecatedWindowsSurvey": {
-          "value": [
-            "survey.dismissed"
           ]
         }
       }

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -13,7 +13,7 @@
           "type": "survey",
           "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3",
           "additionalParameters": {
-            "queryParams": "wv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+            "queryParams": "wv;ddgv;mo;sts;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;"
           }
         }
       },
@@ -37,7 +37,7 @@
           "type": "survey",
           "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_windows_newsubscribersurvey?list=3",
           "additionalParameters": {
-            "queryParams": "wv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+            "queryParams": "wv;ddgv;mo;sts;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;"
           }
         }
       },

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,194 @@
 {
-  "version": 2,
-  "messages": [],
-  "rules": []
+  "version": 3,
+  "messages": [
+    {
+      "id": "windows_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Why You Left Privacy Pro",
+        "descriptionText": "By taking our brief survey, you'll help improve Privacy Pro for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3",
+          "additionalParameters": {
+            "queryParams": "wv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        2
+      ],
+      "exclusionRules": [
+        5,
+        7
+      ]
+    },
+    {
+      "id": "windows_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Your Thoughts on Privacy Pro",
+        "descriptionText": "By completing our brief survey, you will help improve the Privacy Pro experience for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_windows_newsubscribersurvey?list=3",
+          "additionalParameters": {
+            "queryParams": "wv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        4
+      ],
+      "exclusionRules": [
+        5,
+        6,
+        8
+      ]
+    },
+    {
+      "id": "windows_permanent_survey",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve",
+        "descriptionText": "Take our short survey and help us build the best browser.",
+        "placeholder": "Announce",
+        "primaryActionText": "Share Your Thoughts",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/231005?list=1",
+          "additionalParameters": {
+            "queryParams": "wv;atb;ddgv;sts"
+          }
+        }
+      },
+      "matchingRules": [
+        9
+      ],
+      "exclusionRules": [
+        10
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "id": 2,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "stripe"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "expiring"
+          ]
+        },
+        "appVersion": {
+          "min": <TBD>
+        }
+      }
+    },
+    {
+      "id": 4,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "stripe"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "active"
+          ]
+        },
+        "appVersion": {
+          "min": <TBD>
+        }
+      }
+    },
+    {
+      "id": 5,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": [
+            "windows_privacy_pro_exit_survey_1"
+          ]
+        }
+      }
+    },
+    {
+      "id": 6,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": [
+            "windows_privacy_pro_subscriber_survey_1"
+          ]
+        }
+      }
+    },
+    {
+      "id": 7,
+      "attributes": {
+        "interactedWithDeprecatedWindowsSurvey": {
+          "value": [
+            "canceled-subscription-survey.dismissed"
+          ]
+        }
+      }
+    },
+    {
+      "id": 8,
+      "attributes": {
+        "interactedWithDeprecatedWindowsSurvey": {
+          "value": [
+            "new-subscription-survey.dismissed"
+          ]
+        }
+      }
+    },
+    {
+      "id": 9,
+      "attributes": {
+        "appVersion": {
+          "min": <TBD>
+        },
+        "daysSinceInstalled": {
+          "min": 5,
+          "max": 14
+        },
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        }
+      }
+    },
+    {
+      "id": 10,
+      "attributes": {
+        "interactedWithDeprecatedWindowsSurvey": {
+          "value": [
+            "survey.dismissed"
+          ]
+        }
+      }
+    }
+  ]
 }

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -88,9 +88,7 @@
           ]
         },
         "pproSubscriptionStatus": {
-          "value": [
-            "expiring"
-          ]
+          "value": "expiring"
         },
         "appVersion": {
           "min": <TBD>
@@ -112,9 +110,7 @@
           ]
         },
         "pproSubscriptionStatus": {
-          "value": [
-            "active"
-          ]
+          "value": "active"
         },
         "appVersion": {
           "min": <TBD>

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -68,7 +68,7 @@
           "value": "expiring"
         },
         "appVersion": {
-          "min": <TBD>
+          "min": "0.93.0"
         }
       }
     },
@@ -90,7 +90,7 @@
           "value": "active"
         },
         "appVersion": {
-          "min": <TBD>
+          "min": "0.93.0"
         }
       }
     },

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -47,6 +47,7 @@
       "exclusionRules": [
         5,
         6,
+        7,
         8
       ]
     },


### PR DESCRIPTION
**Testing steps (using latest Windows `develop` version):**

**Day 5 Survey** (removed as per https://app.asana.com/0/0/1208496017326914/1208593281742592/f)
~~1. Save the updated config to your device from **Files changed** on GitHub
2. Remove the `appVersion` matching attributes
3. Reset your DuckDuckGo instance
4. Using Developer Options, point the browser to the update RMF config
5. Menu > Debug > Reset data > Change installation date > 10 days ago
6. Restart the app
7. - [ ] Ensure two "Help Us Improve" surveys are showing
8. Menu > Debug > Reset data > Change installation date > 15 days ago
9. Restart the app
10. - [ ] Ensure no "Help Us Improve" surveys are showing
11. Menu > Debug > Reset data > Change installation date > 10 days ago
12. Restart the app
13. Open the survey with the yellow icon and copy the URL, pasting it into Notepad
14. Restart the app
15. - [ ] Ensure no "Help Us Improve" surveys are showing
16. Menu > Debug > Survey > Un-dismiss > Browser Survey
17. Restart the app
18. - [ ] Ensure two "Help Us Improve" surveys are showing
19. Open the survey with the blue icon and copy the URL, pasting it into Notepad
20. - [ ] Ensure the URLs match (params can be any order)~~

**Privacy Pro Subscriber**
1. Subscribe to Privacy Pro via a test subscription
2. In DaysSinceSubscribedMatchingAttribute.cs change the `var daysSinceStarted = ...` line to `var daysSinceStarted = 16;`
3. Launch the app
4. - [ ] Ensure two "Tell Us Your Thoughts About Privacy Pro" surveys are showing
5. Open the first survey and copy the URL, pasting it into Notepad
6. Restart the app
7. - [ ] Ensure no "Tell Us Your Thoughts About Privacy Pro" surveys are showing
8. Menu > Debug > Survey > Un-dismiss > Privacy Pro New subscriber
9. Open the second survey and copy the URL, pasting it into Notepad
10. - [ ] Ensure the URLs match (except for `sts` and `ddgv` params, params can be any order)

**Privacy Pro Exit**
1. Cancel Privacy Pro
2. Restart the app
3. - [ ] Ensure two "Tell Us Why You Left Privacy Pro" surveys are showing
4. Open the first survey and copy the URL, pasting it into Notepad
5. Restart the app
6. - [ ] Ensure no "Tell Us Why You Left Privacy Pro" surveys are showing
7. Menu > Debug > Survey > Un-dismiss > Privacy Pro subscriber canceled
8. Open the second survey and copy the URL, pasting it into Notepad
9. - [ ] Ensure the URLs match (except for `sts` and `ddgv` params, params can be any order)