### PR TITLE
Update macOS permanent survey

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -87,7 +87,7 @@
         "primaryActionText": "Share Your Thoughts",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240404?list=3",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/241004?list=2",
           "additionalParameters": {
             "queryParams": "delta;var;osv;ddgv"
           }
@@ -236,8 +236,8 @@
           "min": "1.106.0"
         },
         "daysSinceInstalled": {
-          "min": 5,
-          "max": 14
+          "min": 14,
+          "max": 21
         },
         "locale": {
           "value": [

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 6,
   "messages": [
     {
       "id": "macos_privacy_pro_app_store_exit_survey_1",


### PR DESCRIPTION
Task: https://app.asana.com/0/1207619243206445/1208593281742593/f

This PR updates the macOS survey with an updated URL and date range.

To test this, check that the date range matches the details in the linked task, and that the URL opens a survey as expected.