### PR TITLE
added preview build CTA

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 4,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -50,9 +50,34 @@
         7,
         8
       ]
+    },
+    {
+      "id": "windows_preview_cta",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Get early access to the latest features in\n DuckDuckGo Preview for Windows",
+        "descriptionText": "Try out the latest browser features and send feedback to help us improve DuckDuckGo.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Learn More",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/windows-preview"
+        }
+      },
+      "matchingRules": [
+        1
+      ]
     }
   ],
   "rules": [
+    {
+      "id": 1,
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 14
+        }
+      }
+    },
     {
       "id": 2,
       "attributes": {


### PR DESCRIPTION
Added preview build CTA message.

Asana - https://app.asana.com/0/1207619243206445/1208576933079651/f

A message to all users to try the windows preview build. To test

1. Set Remote Message config source in settings to https://staticcdn.duckduckgo.com/remotemessaging/config/staging/windows-config.json, and load.
2. If the browser has been installed for less than 14 days, Application menu -> Debug -> Reset Data -> Change Installation Date -> Set to 15 days ago.
3. Message should be visible on new tab page - verify it takes you to https://duckduckgo.com/windows-preview