### PR TITLE
Update macOS Privacy Pro exit survey

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -120,7 +120,7 @@
           "value": ["expiring"]
         },
         "pproDaysUntilExpiryOrRenewal": {
-          "max": 5
+          "max": 10
         },
         "appVersion": {
           "min": "1.101.0"
@@ -143,7 +143,7 @@
           "value": ["expiring"]
         },
         "pproDaysUntilExpiryOrRenewal": {
-          "max": 5
+          "max": 10
         },
         "appVersion": {
           "min": "1.101.0"

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 6,
+  "version": 7,
   "messages": [
     {
       "id": "macos_privacy_pro_app_store_exit_survey_1",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -119,6 +119,9 @@
         "pproSubscriptionStatus": {
           "value": ["expiring"]
         },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 5
+        },
         "appVersion": {
           "min": "1.101.0"
         },
@@ -138,6 +141,9 @@
         },
         "pproSubscriptionStatus": {
           "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 5
         },
         "appVersion": {
           "min": "1.101.0"

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -114,7 +114,7 @@
           "value": true
         },
         "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
+          "value": ["apple"]
         },
         "pproSubscriptionStatus": {
           "value": ["expiring"]
@@ -134,7 +134,7 @@
           "value": true
         },
         "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
+          "value": ["stripe"]
         },
         "pproSubscriptionStatus": {
           "value": ["expiring"]


### PR DESCRIPTION
**Task:** https://app.asana.com/0/1193060753475688/1208652701561219/f

This PR updates the macOS exit survey to use a single platform for each message, and to only show the exit survey to those users who are <= 10 days away from expiration.

**Testing steps:**

To test this requires signing into a Privacy Pro account and then making some local tweaks to meet the criteria.

1. Sign into a Privacy Pro account
2. Update `RemoteMessagingClient.swift` to use the [staging URL](https://staticcdn.duckduckgo.com/remotemessaging/config/staging/macos-config.json) in debug mode
3. Update the variables in `RemoteMessagingConfigMatcherProvider` to match what you want - in this case, set `privacyProDaysUntilExpiry` to 4, and `privacyProPurchasePlatform` to `stripe` (particularly important if you have an employee account, since it has a custom purchase platform)
4. Finally, launch the app and use the debug menu to reset and refresh remote messages if needed
5. If the message doesn't appear, it may be because you have interacted with it before, or interacted with the deprecated remote messaging feature - you can try and pass empty arrays for `dismissedDeprecatedMacRemoteMessageIds` and `dismissedMessageIds` in `RemoteMessagingConfigMatcherProvider` to get around this