### PR TITLE
Added windows 14 day survey

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -71,7 +71,7 @@
         9
       ]
     },
-	{
+    {
       "id": "windows_14_day_survey",
       "content": {
         "messageType": "big_single_action",
@@ -196,15 +196,15 @@
       "attributes": {
         "flavor": {
           "value": ["beta", "dev", "canary", "preview"]
-		  }
+        }
       }
     },
-	{
+    {
       "id": 10,
       "attributes": {
         "daysSinceInstalled": {
           "min": 14,
-		  "max": 21
+          "max": 21
         },
         "appVersion": {
           "min": "0.93.0"
@@ -219,7 +219,7 @@
         }
       }
     },
-	{
+    {
       "id": 11,
       "attributes": {
         "interactedWithDeprecatedWindowsSurvey": {

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 8,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -69,6 +69,29 @@
       ],
       "exclusionRules": [
         9
+      ]
+    },
+	{
+      "id": "windows_14_day_survey",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve",
+        "descriptionText": "Take our short survey and help us build the best browser.",
+        "placeholder": "Announce",
+        "primaryActionText": "Share Your Thoughts",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/241004?list=1",
+          "additionalParameters": {
+            "queryParams": "wv;atb;ddgv;sts;var;origin;"
+          }
+        }
+      },
+      "matchingRules": [
+        10
+      ],
+      "exclusionRules": [
+        11
       ]
     }
   ],
@@ -173,6 +196,36 @@
       "attributes": {
         "flavor": {
           "value": ["beta", "dev", "canary", "preview"]
+		  }
+      }
+    },
+	{
+      "id": 10,
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 14,
+		  "max": 21
+        },
+        "appVersion": {
+          "min": "0.93.0"
+        },
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        }
+      }
+    },
+	{
+      "id": 11,
+      "attributes": {
+        "interactedWithDeprecatedWindowsSurvey": {
+          "value": [
+            "survey.dismissed"
+          ]
         }
       }
     }

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -13,7 +13,7 @@
           "type": "survey",
           "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3",
           "additionalParameters": {
-            "queryParams": "wv;ddgv;mo;sts;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;"
+            "queryParams": "wv;ddgv;mo;sts;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
         }
       },
@@ -37,7 +37,7 @@
           "type": "survey",
           "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_windows_newsubscribersurvey?list=3",
           "additionalParameters": {
-            "queryParams": "wv;ddgv;mo;sts;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;"
+            "queryParams": "wv;ddgv;mo;sts;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
         }
       },
@@ -83,7 +83,7 @@
           "type": "survey",
           "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/241004?list=1",
           "additionalParameters": {
-            "queryParams": "wv;atb;ddgv;sts;var;origin;"
+            "queryParams": "wv;atb;ddgv;sts;var;origin"
           }
         }
       },


### PR DESCRIPTION
Added permeant 14 day survey for windows. This is active where 

- the install date is between 14 and 21 days
- the locale is `en-US`, `en-CA`, `en-GB` or `en-AU`
- the user is on app version 0.93.0 
   - This is because there's a new survey parameter that's been added in 0.93.0
- the user hasn't previously interacted with the old non RMF survey with value `survey.dismissed`

Don't merge this at the moment - since 0.93.0 has not been released to stable yet.