### PR TITLE
Updated preview message to not show on preview builds

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -66,6 +66,9 @@
       },
       "matchingRules": [
         1
+      ],
+      "exclusionRules": [
+        9
       ]
     }
   ],
@@ -75,9 +78,6 @@
       "attributes": {
         "daysSinceInstalled": {
           "min": 14
-        },
-        "flavor": {
-          "value": "stable"
         }
       }
     },
@@ -159,6 +159,14 @@
           "value": [
             "new-subscription-survey.dismissed"
           ]
+        }
+      }
+    },
+    {
+      "id": 9,
+      "attributes": {
+        "flavor": {
+          "value": ["beta", "dev", "canary", "preview"]
         }
       }
     }

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 6,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -75,7 +75,10 @@
       "attributes": {
         "daysSinceInstalled": {
           "min": 14
-        }
+        },
+		"flavor": {
+          "value": "dev|canary|beta|stable"
+		}
       }
     },
     {

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -76,9 +76,9 @@
         "daysSinceInstalled": {
           "min": 14
         },
-		"flavor": {
-          "value": "dev|canary|beta|stable"
-		}
+        "flavor": {
+          "value": "stable"
+        }
       }
     },
     {


### PR DESCRIPTION
This stops the preview CTA message from showing on preview builds. To test

1. Load a preview version of the browser
2. Make sure you installed more than 14 days ago - you can use Debug -> Data -> Change installation Date -> set to 15 days ago if need be.
3. Go to Settings -> Developer Settings -> and scroll down to the Remote Message Config Controls section. Press 'Clear Local Store' then 'Force Parse' (in case you've already dismissed the existing preview message).
4. On the new tab page you should see a remote message inviting you to try preview (don't interact with it or close it).
5. In the Remote Message Config Controls settings, update the path to be https://staticcdn.duckduckgo.com/remotemessaging/config/staging/windows-config.json , then press 'Force Load'.
6. On the new tab page you should no longer see the remote message.
7. Load a stable version of the browser
8. Set the RMF config as in step 3.
9. On the new tab page you should see the remote message inviting you to try the preview.