### PR TITLE
removed preview cta message

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 6,
+  "version": 7,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -50,37 +50,9 @@
         7,
         8
       ]
-    },
-    {
-      "id": "windows_preview_cta",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Get early access to the latest features in \nDuckDuckGo Preview for Windows",
-        "descriptionText": "Try out the latest browser features and send feedback to help us improve DuckDuckGo.",
-        "placeholder": "DDGAnnounce",
-        "primaryActionText": "Learn More",
-        "primaryAction": {
-          "type": "url",
-          "value": "https://duckduckgo.com/windows-preview"
-        }
-      },
-      "matchingRules": [
-        1
-      ],
-      "exclusionRules": [
-        9
-      ]
     }
   ],
   "rules": [
-    {
-      "id": 1,
-      "attributes": {
-        "daysSinceInstalled": {
-          "min": 14
-        }
-      }
-    },
     {
       "id": 2,
       "attributes": {
@@ -159,14 +131,6 @@
           "value": [
             "new-subscription-survey.dismissed"
           ]
-        }
-      }
-    },
-    {
-      "id": 9,
-      "attributes": {
-        "flavor": {
-          "value": ["beta", "dev", "canary", "preview"]
         }
       }
     }


### PR DESCRIPTION
https://app.asana.com/0/1207619243206445/1208576933079651/f

This is to remove the Preview Build CTA remote message as we don't want it to currently be shown.