### PR TITLE
Reapply "New message for privacy pro promotion with origin"

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 50,
+  "version": 49,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -42,6 +42,23 @@
       ],
       "exclusionRules": [
         3
+      ]
+    },
+    {
+      "id": "funnel_pro_iosrmf_announcement",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Enjoy peace of mind with our VPN!",
+        "descriptionText": "Boost protection with a fast, secure VPN + 2 more premium services.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Get Privacy Pro",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/pro?origin=funnel_pro_iosrmf_announcement"
+        }
+      },
+      "matchingRules": [
+        5
       ]
     },
     {
@@ -125,6 +142,23 @@
         },
         "appVersion": {
           "min": "7.124.0.1"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "attributes": {
+        "pproSubscriber": {
+          "value": false
+        },
+        "pproEligible": {
+          "value": true
+        },
+        "locale": {
+          "value": ["en-US"]
+        },
+        "appVersion": {
+          "min": "7.131.0.1"
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 49,
+  "version": 51,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -158,7 +158,7 @@
           "value": ["en-US"]
         },
         "appVersion": {
-          "min": "7.131.0.1"
+          "min": "7.149.0.2"
         }
       }
     }


### PR DESCRIPTION
Reverts duckduckgo/remote-messaging-config#125

This PR re-enables the PPro promotion with origin message, but with an increased minimum app version.