### PR TITLE
Remove Q4 2024 iOS quarterly survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 54,
+  "version": 55,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -62,29 +62,6 @@
       },
       "matchingRules": [
         4
-      ]
-    },
-    {
-      "id": "ios_quarterly_satisfaction_survey_q4_2024_part_2",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "Announce",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240903?list=4",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;locale"
-          }
-        }
-      },
-      "matchingRules": [
-        6
-      ],
-      "exclusionRules": [
-        1, 2, 7
       ]
     }
   ],
@@ -154,42 +131,6 @@
         },
         "appVersion": {
           "min": "7.124.0.1"
-        }
-      }
-    },
-    {
-      "id": 6,
-      "targetPercentile": {
-        "before": 0.25
-      },
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
-          ]
-        },
-        "appVersion": {
-          "min": "7.123.0.0"
-        }
-      }
-    },
-    {
-      "id": 7,
-      "attributes": {
-        "interactedWithMessage": {
-          "value": [
-            "ddg_ios_survey_1",
-            "ios_quarterly_satisfaction_survey_q4_2024"
-          ]
-        },
-        "messageShown": {
-          "value": [
-            "ddg_ios_survey_1",
-            "ios_quarterly_satisfaction_survey_q4_2024"
-          ]
         }
       }
     }


### PR DESCRIPTION
Task: https://app.asana.com/0/0/1209004120118368/f

This PR takes down the survey added in https://github.com/duckduckgo/remote-messaging-config/pull/131.

**How to test:**
- Check that this PR correctly reverts the changes added in https://github.com/duckduckgo/remote-messaging-config/pull/131 and bumps the version number