### PR TITLE
Remove quarterly Dec 2024 survey

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 43,
+  "version": 44,
   "messages": [
     {
       "id": "android_privacy_pro_exit_survey_1",
@@ -42,29 +42,6 @@
       ],
       "exclusionRules": [
         8
-      ]
-    },
-    {
-      "id": "android_quarterly_satisfaction_survey_1224",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "Announce",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240903?list=3",
-          "additionalParameters": {
-            "queryParams": "var;delta;av;ddgv"
-          }
-        }
-      },
-      "matchingRules": [
-        11
-      ],
-      "exclusionRules": [
-        6, 7, 12
       ]
     },
     {
@@ -208,36 +185,6 @@
           "value": [
             "android_quarterly_satisfaction_survey_q4_2024",
             "android_quarterly_satisfaction_survey_1224"
-          ]
-        }
-      }
-    },
-    {
-      "id": 11,
-      "targetPercentile": {
-        "before": 0.25
-      },
-      "attributes": {
-        "appVersion": {
-          "min": "5.204.0"
-        },
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
-          ]
-        }
-      }
-    },
-    {
-      "id": 12,
-      "attributes": {
-        "interactedWithMessage": {
-          "value": [
-            "android_quarterly_satisfaction_survey_q4_2024",
-            "android_permanent_survey_user_satisfaction"
           ]
         }
       }


### PR DESCRIPTION
Task: https://app.asana.com/0/1201807753394693/1209004097100185

This PR takes down the survey added in https://github.com/duckduckgo/remote-messaging-config/pull/132.

**How to test:**
- Check that this PR correctly reverts the changes added in https://github.com/duckduckgo/remote-messaging-config/pull/132 and bumps the version number