### PR TITLE
Added workaround for daysSinceInstalled matching attribute.

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -100,7 +100,8 @@
       "id": 1,
       "attributes": {
         "daysSinceInstalled": {
-          "min": 14
+          "min": 14,
+          "max": 10000
         }
       }
     },


### PR DESCRIPTION
daysSinceInstalled matching attribute has a bug where the install date is set as 01/01/0001. This means the matching attribute thinks the browser has been installed for over 700,000 days, causing `min` comparisons to incorrectly return true.

Added a "max" comparison to not shown the message under these circumstances.