### PR TITLE
re-added workaround to not display preview for installs with no AtbInitDate

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 8,
+  "version": 9,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -100,7 +100,8 @@
       "id": 1,
       "attributes": {
         "daysSinceInstalled": {
-          "min": 14
+          "min": 14,
+          "max": 10000
         }
       }
     },


### PR DESCRIPTION
daysSinceInstalled matching attribute has a bug where the install date is set as 01/01/0001. This means the matching attribute thinks the browser has been installed for over 700,000 days, causing min comparisons to incorrectly return true.

Added a "max" comparison to not shown the message under these circumstances.

See also - https://github.com/duckduckgo/remote-messaging-config/pull/136

This was reverted as we thought this was causing stable to break on non UTC timezones. This was a false alarm - this message is fine. (checked on timezones + and - from UTC)