### PR TITLE
Added percentile argument to windows 14 day survey

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 10,
+  "version": 11,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -165,6 +165,9 @@
     },
     {
       "id": 10,
+      "targetPercentile": {
+        "before": 0.5
+      },
       "attributes": {
         "daysSinceInstalled": {
           "min": 14,


### PR DESCRIPTION
The windows 14 day survey has more than enough responses at the moment. Add a percentile argument to only show this to 50% of users.