### PR TITLE
re-enabled preview cta remote message

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -73,9 +73,38 @@
       "exclusionRules": [
         11
       ]
+    },
+    {
+      "id": "windows_preview_cta",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Get early access to the latest features in \nDuckDuckGo Preview for Windows",
+        "descriptionText": "Try out the latest browser features and send feedback to help us improve DuckDuckGo.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Learn More",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/windows-preview"
+        }
+      },
+      "matchingRules": [
+        1
+      ],
+      "exclusionRules": [
+        9
+      ]
     }
   ],
   "rules": [
+    {
+      "id": 1,
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 14,
+          "max": 10000
+        }
+      }
+    },
     {
       "id": 2,
       "attributes": {
@@ -94,7 +123,7 @@
           "min": "0.93.0"
         },
         "locale": {
-          "value": ["en-US"]
+          "value": [ "en-US" ]
         }
       }
     },
@@ -119,7 +148,7 @@
           "min": "0.93.0"
         },
         "locale": {
-          "value": ["en-US"]
+          "value": [ "en-US" ]
         }
       }
     },
@@ -160,6 +189,14 @@
           "value": [
             "new-subscription-survey.dismissed"
           ]
+        }
+      }
+    },
+    {
+      "id": 9,
+      "attributes": {
+        "flavor": {
+          "value": [ "beta", "dev", "canary", "preview" ]
         }
       }
     },


### PR DESCRIPTION
https://app.asana.com/0/0/1209302986770759/f

This re-enables the 'Try the preview browser' remote message.