### PR TITLE
windows quarterly survey

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -73,6 +73,75 @@
       "exclusionRules": [
         11
       ]
+    },
+    {
+      "id": "windows_quarterly_satisfaction_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve",
+        "descriptionText": "Take our short survey and help us build the best browser.",
+        "placeholder": "Announce",
+        "primaryActionText": "Share Your Thoughts",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/250206?list=1",
+          "additionalParameters": {
+            "queryParams": "wv;delta;ddgv;sts;var"
+          }
+        }
+      },
+      "matchingRules": [
+        12
+      ],
+      "exclusionRules": [
+        13
+      ]
+    },
+    {
+      "id": "windows_quarterly_satisfaction_survey_2",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve",
+        "descriptionText": "Take our short survey and help us build the best browser.",
+        "placeholder": "Announce",
+        "primaryActionText": "Share Your Thoughts",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/250206?list=1",
+          "additionalParameters": {
+            "queryParams": "wv;delta;ddgv;sts;var"
+          }
+        }
+      },
+      "matchingRules": [
+        14
+      ],
+      "exclusionRules": [
+        15
+      ]
+    },
+    {
+      "id": "windows_quarterly_satisfaction_survey_3",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve",
+        "descriptionText": "Take our short survey and help us build the best browser.",
+        "placeholder": "Announce",
+        "primaryActionText": "Share Your Thoughts",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/250206?list=1",
+          "additionalParameters": {
+            "queryParams": "wv;delta;ddgv;sts;var"
+          }
+        }
+      },
+      "matchingRules": [
+        16
+      ],
+      "exclusionRules": [
+        17
+      ]
     }
   ],
   "rules": [
@@ -94,7 +163,7 @@
           "min": "0.93.0"
         },
         "locale": {
-          "value": ["en-US"]
+          "value": [ "en-US" ]
         }
       }
     },
@@ -119,7 +188,7 @@
           "min": "0.93.0"
         },
         "locale": {
-          "value": ["en-US"]
+          "value": [ "en-US" ]
         }
       }
     },
@@ -193,6 +262,90 @@
           "value": [
             "survey.dismissed"
           ]
+        }
+      }
+    },
+    {
+      "id": 12,
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 29,
+          "max": 10000
+        },
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        }
+      }
+    },
+    {
+      "id": 13,
+      "attributes": {
+        "messageShown": {
+          "value": [ "windows_14_day_survey", "windows_quarterly_satisfaction_survey_2", "windows_quarterly_satisfaction_survey_3" ]
+        }
+      }
+    },
+    {
+      "id": 14,
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 111,
+          "max": 10000
+        },
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        },
+        "messageShown": {
+          "value": [ "windows_14_day_survey" ]
+        }
+      }
+    },
+    {
+      "id": 15,
+      "attributes": {
+        "messageShown": {
+          "value": [ "windows_quarterly_satisfaction_survey_1", "windows_quarterly_satisfaction_survey_3" ]
+        }
+      }
+    },
+    {
+      "id": 16,
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 29,
+          "max": 10000
+        },
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        },
+        "messageShown": {
+          "value": [ "windows_14_day_survey" ]
+        }
+      }
+    },
+    {
+      "id": 17,
+      "attributes": {
+        "messageShown": {
+          "value": [ "windows_quarterly_satisfaction_survey_1", "windows_quarterly_satisfaction_survey_2" ]
+        },
+        "interactedWithMessage": {
+          "value": [ "windows_14_day_survey" ]
         }
       }
     }

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 11,
+  "version": 12,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",


### PR DESCRIPTION
This adds the quarterly survey RMF message(s).

The logic is tricky! I've created 3 messages to work around some limitations in our matching attributes. For `messageShown` and `interactedWithMessage` we can't currently have the logic 'message with id <messageId> has not been shown' in an inclusion rule. The logic is

- english speaking
- installed more than 28 days ago
  - has not seen day 14 invite (`windows_14_day_survey`) OR
  - has seen day 14 invite but did not interact with it OR
  - has seen the day 14 invite more than 3 months ago
  
We need to split this into 3 messages

### Message 1 (users that haven't seen the 14 day survey)
#### Include if 
- english speaking
- install date min 29 days ago (the matching attribute `min` is inclusive so 29 to target more than 28 days since install)
#### Exclude if 
- Has seen `windows_14_day_survey` message
- Has seen message 2 or 3

### Message 2 (users that interacted with the 14 day survey more than 3 months ago)
#### Include if 
- english speaking
- install date min 111 days ago (workaround - this defines a user who has seen the 14 day message more than 3 months ago)
- Has seen `windows_14_day_survey` message
#### Exclude if 
- Has seen message 1 or 3

### Message 3 (users that haven't interacted with the 14 day survey)
#### Include if 
- english speaking
- install date min 29 days ago
- Has seen `windows_14_day_survey` message
#### Exclude if 
- Has seen message 1 or 2
- Has interacted with `windows_14_day_survey` message