### PR TITLE
Re-enabled windows preview CTA, with 15% percentile.

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -142,9 +142,41 @@
       "exclusionRules": [
         17
       ]
+    },
+    {
+      "id": "windows_preview_cta",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Get early access to the latest features in \nDuckDuckGo Preview for Windows",
+        "descriptionText": "Try out the latest browser features and send feedback to help us improve DuckDuckGo.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Learn More",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/windows-preview"
+        }
+      },
+      "matchingRules": [
+        1
+      ],
+      "exclusionRules": [
+        9
+      ]
     }
   ],
   "rules": [
+    {
+      "id": 1,
+      "targetPercentile": {
+        "before": 0.15
+      },
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 14,
+          "max": 10000
+        }
+      }
+    },
     {
       "id": 2,
       "attributes": {
@@ -229,6 +261,14 @@
           "value": [
             "new-subscription-survey.dismissed"
           ]
+        }
+      }
+    },
+    {
+      "id": 9,
+      "attributes": {
+        "flavor": {
+          "value": [ "beta", "dev", "canary", "preview" ]
         }
       }
     },

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -168,7 +168,7 @@
     {
       "id": 1,
       "targetPercentile": {
-        "before": 0.15
+        "before": 0.85
       },
       "attributes": {
         "daysSinceInstalled": {


### PR DESCRIPTION
https://app.asana.com/0/1207619243206445/1208576933079651

This re-enables the remote message advertising the windows preview build - with an added percentile rule to only show it to 15% of eligible users.

This is tricky to test, since there's currently no way to force your install to fall within a particular percentile! (Will try to extend RMF debug to support this at some point). This exact remote message has been in production before however.