### PR TITLE
Translated Privacy Pro surveys for iOS & macOS

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -64,12 +64,11 @@
         4
       ]
     },
-
     {
       "id": "ios_privacy_pro_exit_survey_fr",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Pourquoi avez-vous annulé Privacy Pro?",
+        "titleText": "Vous avez arrêté votre abonnement ? Dites-nous tout.",
         "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Lancer le sondage",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -11,7 +11,7 @@
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&ppro_region=us",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -19,6 +19,26 @@
       },
       "matchingRules": [
         2
+      ]
+    },
+    {
+      "id": "ios_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Why You Left Privacy Pro",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        17
       ]
     },
     {
@@ -31,7 +51,7 @@
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&ppro_region=us",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -39,6 +59,29 @@
       },
       "matchingRules": [
         1
+      ],
+      "exclusionRules": [
+        3
+      ]
+    },
+    {
+      "id": "ios_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Your Thoughts on Privacy Pro",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        18
       ],
       "exclusionRules": [
         3
@@ -173,7 +216,7 @@
       "matchingRules": [10]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_translated",
+      "id": "ios_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Faites-nous part de votre avis sur Privacy Pro",
@@ -196,7 +239,7 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_translated",
+      "id": "ios_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Was halten Sie von Privacy Pro?",
@@ -219,7 +262,7 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_translated",
+      "id": "ios_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waar denkt u aan bij Privacy Pro",
@@ -242,7 +285,7 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_translated",
+      "id": "ios_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cosa ne pensa di Privacy Pro?",
@@ -265,7 +308,7 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_translated",
+      "id": "ios_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "¿Qué opina del producto Privacy Pro?",
@@ -288,7 +331,7 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_translated",
+      "id": "ios_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Vad tycker du om Privacy Pro?",
@@ -674,6 +717,49 @@
           ]
         }
       }
-    }
+    },
+    {
+      "id": 17,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": ["en-CA", "en-UK"]
+        }
+      }
+    },
+    {
+      "id": 18,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": ["en-CA", "en-UK"]
+        }
+      }
+    },
   ]
 }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -17,9 +17,7 @@
           }
         }
       },
-      "matchingRules": [
-        2
-      ]
+      "matchingRules": [2]
     },
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -37,79 +35,8 @@
           }
         }
       },
-      "matchingRules": [
-        17
-      ]
+      "matchingRules": [17]
     },
-    {
-      "id": "ios_privacy_pro_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&ppro_region=us",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [
-        1
-      ],
-      "exclusionRules": [
-        3
-      ]
-    },
-    {
-      "id": "ios_privacy_pro_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [
-        18
-      ],
-      "exclusionRules": [
-        3
-      ]
-    },
-    {
-      "id": "ddg_ios_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "Announce",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240200?list=3",
-          "additionalParameters": {
-            "queryParams": "atb;var;ddgv;mo;osv"
-          }
-        }
-      },
-      "matchingRules": [
-        4
-      ]
-    },
-
-
-
     {
       "id": "ios_privacy_pro_exit_survey_1",
       "content": {
@@ -220,7 +147,52 @@
     },
 
 
-
+    {
+      "id": "ios_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Your Thoughts on Privacy Pro",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&ppro_region=us",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        1
+      ],
+      "exclusionRules": [
+        3
+      ]
+    },
+    {
+      "id": "ios_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Your Thoughts on Privacy Pro",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        18
+      ],
+      "exclusionRules": [
+        3
+      ]
+    },
     {
       "id": "ios_privacy_pro_subscriber_survey_1",
       "content": {
@@ -357,6 +329,28 @@
       ],
       "exclusionRules": [
         3
+      ]
+    },
+
+
+    {
+      "id": "ddg_ios_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help us improve the app!",
+        "descriptionText": "Take our short anonymous survey and share your feedback.",
+        "placeholder": "Announce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240200?list=3",
+          "additionalParameters": {
+            "queryParams": "atb;var;ddgv;mo;osv"
+          }
+        }
+      },
+      "matchingRules": [
+        4
       ]
     }
   ],

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -107,6 +107,9 @@
         4
       ]
     },
+
+
+
     {
       "id": "ios_privacy_pro_exit_survey_1",
       "content": {
@@ -215,6 +218,9 @@
       },
       "matchingRules": [10]
     },
+
+
+
     {
       "id": "ios_privacy_pro_subscriber_survey_1",
       "content": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -105,7 +105,7 @@
       "id": "ios_privacy_pro_exit_survey_nl",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Vertel ons waarom je Privacy Pro hebt verlaten",
+        "titleText": "Waarom heeft u Privacy Pro opgezegd?",
         "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u ons Privacy Pro voor alle abonnees te verbeteren.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Enquête starten",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -176,7 +176,7 @@
       "id": "ios_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Faites-nous part de votre avis sur Privacy Pro",
+        "titleText": "Faites-nous part de votre avis sur Privacy Pro",
         "descriptionText": "En répondant à notre court sondage, vous contribuerez à l'amélioration de Privacy Pro pour l'ensemble de nos abonnés.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Lancer le sondage",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -74,7 +74,7 @@
         "primaryActionText": "Lancer le sondage",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=french",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=french&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -92,7 +92,7 @@
         "primaryActionText": "Umfrage starten",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=german",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=german&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -110,7 +110,7 @@
         "primaryActionText": "Enquête starten",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=dutch",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=dutch&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -128,7 +128,7 @@
         "primaryActionText": "Inizia l'indagine",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=italian",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=italian&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -146,7 +146,7 @@
         "primaryActionText": "Empezar encuesta",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=spanish_eu",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=spanish_eu&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -164,7 +164,7 @@
         "primaryActionText": "Starta enkät",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=swedish",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=swedish&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -182,7 +182,7 @@
         "primaryActionText": "Lancer le sondage",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&decLang=french",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&decLang=french&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -123,8 +123,8 @@
       "id": "ios_privacy_pro_exit_survey_it",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Dicci perché hai lasciato Privacy Pro",
-        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterai a migliorare Privacy Pro per tutti gli abbonati.",
+        "titleText": "Ci dica perché ha lasciato Privacy Pro",
+        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterà a migliorare Privacy Pro per tutti gli abbonati.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Inizia l'indagine",
         "primaryAction": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -65,7 +65,7 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_exit_survey_translated",
+      "id": "ios_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Vous avez arrêté votre abonnement ? Dites-nous tout.",
@@ -83,7 +83,7 @@
       "matchingRules": [5]
     },
     {
-      "id": "ios_privacy_pro_exit_survey_translated",
+      "id": "ios_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Warum haben Sie Privacy Pro gekündigt?",
@@ -101,7 +101,7 @@
       "matchingRules": [6]
     },
     {
-      "id": "ios_privacy_pro_exit_survey_translated",
+      "id": "ios_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waarom heeft u Privacy Pro opgezegd?",
@@ -119,7 +119,7 @@
       "matchingRules": [7]
     },
     {
-      "id": "ios_privacy_pro_exit_survey_translated",
+      "id": "ios_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Ci dica perché ha lasciato Privacy Pro",
@@ -137,7 +137,7 @@
       "matchingRules": [8]
     },
     {
-      "id": "ios_privacy_pro_exit_survey_translated",
+      "id": "ios_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cuéntenos por qué dejó Privacy Pro",
@@ -155,7 +155,7 @@
       "matchingRules": [9]
     },
     {
-      "id": "ios_privacy_pro_exit_survey_translated",
+      "id": "ios_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Berätta varför du lämnade Privacy Pro",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 55,
+  "version": 56,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -760,6 +760,6 @@
           "value": ["en-CA", "en-UK"]
         }
       }
-    },
+    }
   ]
 }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -72,7 +72,7 @@
         "titleText": "Pourquoi avez-vous annulé Privacy Pro?",
         "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
         "placeholder": "PrivacyShield",
-        "primaryActionText": "Démarrer l'enquête",
+        "primaryActionText": "Lancer le sondage",
         "primaryAction": {
           "type": "survey",
           "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=french",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -154,6 +154,24 @@
         }
       },
       "matchingRules": [9]
+    },
+    {
+      "id": "ios_privacy_pro_exit_survey_sv",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Berätta varför du lämnade Privacy Pro",
+        "descriptionText": "Genom att svara på vår korta enkät hjälper du oss att förbättra Privacy Pro för alla prenumeranter.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Starta undersökning",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=swedish",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [10]
     }
   ],
   "rules": [
@@ -338,6 +356,28 @@
         "locale": {
           "value": [
             "es-ES"
+          ]
+        }
+      }
+    },
+    {
+      "id": 10,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": [
+            "sv-SE"
           ]
         }
       }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -63,6 +63,97 @@
       "matchingRules": [
         4
       ]
+    },
+
+    {
+      "id": "ios_privacy_pro_exit_survey_fr",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Pourquoi avez-vous annulé Privacy Pro?",
+        "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Démarrer l'enquête",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=french",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [5]
+    },
+    {
+      "id": "ios_privacy_pro_exit_survey_de",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Warum haben Sie Privacy Pro gekündigt?",
+        "descriptionText": "Durch Teilnahme an unserer kurzen Umfrage helfen Sie uns, Privacy Pro für alle Abonnenten zu verbessern.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Umfrage starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=german",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [6]
+    },
+    {
+      "id": "ios_privacy_pro_exit_survey_nl",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Vertel ons waarom je Privacy Pro hebt verlaten",
+        "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u ons Privacy Pro voor alle abonnees te verbeteren.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Enquête starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=dutch",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [7]
+    },
+    {
+      "id": "ios_privacy_pro_exit_survey_it",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Dicci perché hai lasciato Privacy Pro",
+        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterai a migliorare Privacy Pro per tutti gli abbonati.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Inizia l'indagine",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=italian",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [8]
+    },
+    {
+      "id": "ios_privacy_pro_exit_survey_es",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Cuéntanos por qué dejaste Privacy Pro",
+        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudarás a mejorar Privacy Pro para todos los suscriptores.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Empezar encuesta",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=spanish_eu",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [9]
     }
   ],
   "rules": [
@@ -131,6 +222,123 @@
         },
         "appVersion": {
           "min": "7.124.0.1"
+        }
+      }
+    },
+
+    {
+      "id": 5,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": [
+            "fr-FR",
+            "fr-CA",
+            "fr-BE",
+            "fr-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 6,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": [
+            "de-DE",
+            "de-AT",
+            "de-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 7,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": [
+            "nl-NL",
+            "nl-BE"
+          ]
+        }
+      }
+    },
+    {
+      "id": 8,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": [
+            "it-IT"
+          ]
+        }
+      }
+    },
+    {
+      "id": 9,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": [
+            "es-ES"
+          ]
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -65,7 +65,7 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_exit_survey_fr",
+      "id": "ios_privacy_pro_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Vous avez arrêté votre abonnement ? Dites-nous tout.",
@@ -83,7 +83,7 @@
       "matchingRules": [5]
     },
     {
-      "id": "ios_privacy_pro_exit_survey_de",
+      "id": "ios_privacy_pro_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Warum haben Sie Privacy Pro gekündigt?",
@@ -101,7 +101,7 @@
       "matchingRules": [6]
     },
     {
-      "id": "ios_privacy_pro_exit_survey_nl",
+      "id": "ios_privacy_pro_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waarom heeft u Privacy Pro opgezegd?",
@@ -119,7 +119,7 @@
       "matchingRules": [7]
     },
     {
-      "id": "ios_privacy_pro_exit_survey_it",
+      "id": "ios_privacy_pro_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Ci dica perché ha lasciato Privacy Pro",
@@ -137,7 +137,7 @@
       "matchingRules": [8]
     },
     {
-      "id": "ios_privacy_pro_exit_survey_es",
+      "id": "ios_privacy_pro_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cuéntenos por qué dejó Privacy Pro",
@@ -155,7 +155,7 @@
       "matchingRules": [9]
     },
     {
-      "id": "ios_privacy_pro_exit_survey_sv",
+      "id": "ios_privacy_pro_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Berätta varför du lämnade Privacy Pro",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -6,7 +6,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Why You Left Privacy Pro",
-        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
@@ -26,7 +26,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
@@ -70,7 +70,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Pourquoi avez-vous annulé Privacy Pro?",
-        "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
+        "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Démarrer l'enquête",
         "primaryAction": {
@@ -88,7 +88,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Warum haben Sie Privacy Pro gekündigt?",
-        "descriptionText": "Durch Teilnahme an unserer kurzen Umfrage helfen Sie uns, Privacy Pro für alle Abonnenten zu verbessern.",
+        "descriptionText": "Durch Teilnahme an unserer kurzen Umfrage helfen Sie uns, Privacy Pro für alle Abonnenten zu verbessern.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Umfrage starten",
         "primaryAction": {
@@ -106,7 +106,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waarom heeft u Privacy Pro opgezegd?",
-        "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u ons Privacy Pro voor alle abonnees te verbeteren.",
+        "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u ons Privacy Pro voor alle abonnees te verbeteren.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Enquête starten",
         "primaryAction": {
@@ -124,7 +124,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Ci dica perché ha lasciato Privacy Pro",
-        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterà a migliorare Privacy Pro per tutti gli abbonati.",
+        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterà a migliorare Privacy Pro per tutti gli abbonati.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Inizia l'indagine",
         "primaryAction": {
@@ -142,7 +142,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cuéntanos por qué dejaste Privacy Pro",
-        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudarás a mejorar Privacy Pro para todos los suscriptores.",
+        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudarás a mejorar Privacy Pro para todos los suscriptores.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Empezar encuesta",
         "primaryAction": {
@@ -160,7 +160,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Berätta varför du lämnade Privacy Pro",
-        "descriptionText": "Genom att svara på vår korta enkät hjälper du oss att förbättra Privacy Pro för alla prenumeranter.",
+        "descriptionText": "Genom att svara på vår korta enkät hjälper du oss att förbättra Privacy Pro för alla prenumeranter.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Starta enkät",
         "primaryAction": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -173,7 +173,7 @@
       "matchingRules": [10]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_fr",
+      "id": "ios_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Faites-nous part de votre avis sur Privacy Pro",
@@ -196,7 +196,7 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_de",
+      "id": "ios_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Was halten Sie von Privacy Pro?",
@@ -219,7 +219,7 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_nl",
+      "id": "ios_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waar denkt u aan bij Privacy Pro",
@@ -242,7 +242,7 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_it",
+      "id": "ios_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cosa ne pensa di Privacy Pro?",
@@ -265,7 +265,7 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_es",
+      "id": "ios_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "¿Qué opina del producto Privacy Pro?",
@@ -288,7 +288,7 @@
       ]
     },
     {
-      "id": "ios_privacy_pro_subscriber_survey_sv",
+      "id": "ios_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Vad tycker du om Privacy Pro?",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -141,8 +141,8 @@
       "id": "ios_privacy_pro_exit_survey_es",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Cuéntanos por qué dejaste Privacy Pro",
-        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudarás a mejorar Privacy Pro para todos los suscriptores.",
+        "titleText": "Cuéntenos por qué dejó Privacy Pro",
+        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudará a mejorar Privacy Pro para todos los suscriptores.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Empezar encuesta",
         "primaryAction": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -162,7 +162,7 @@
         "titleText": "Berätta varför du lämnade Privacy Pro",
         "descriptionText": "Genom att svara på vår korta enkät hjälper du oss att förbättra Privacy Pro för alla prenumeranter.",
         "placeholder": "PrivacyShield",
-        "primaryActionText": "Starta undersökning",
+        "primaryActionText": "Starta enkät",
         "primaryAction": {
           "type": "survey",
           "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=swedish",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -171,6 +171,144 @@
         }
       },
       "matchingRules": [10]
+    },
+    {
+      "id": "ios_privacy_pro_subscriber_survey_fr",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Faites-nous part de votre avis sur Privacy Pro",
+        "descriptionText": "En répondant à notre court sondage, vous contribuerez à l'amélioration de Privacy Pro pour l'ensemble de nos abonnés.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Lancer le sondage",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&decLang=french",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        11
+      ],
+      "exclusionRules": [
+        3
+      ]
+    },
+    {
+      "id": "ios_privacy_pro_subscriber_survey_de",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Was halten Sie von Privacy Pro?",
+        "descriptionText": "Wenn Sie an unserer kurzen Umfrage teilnehmen, werden wir Ihre Eingaben verwenden, um Privacy Pro für alle Abonnenten zu verbessern.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Umfrage starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&decLang=german",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        12
+      ],
+      "exclusionRules": [
+        3
+      ]
+    },
+    {
+      "id": "ios_privacy_pro_subscriber_survey_nl",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Waar denkt u aan bij Privacy Pro",
+        "descriptionText": "Als u onze korte enquête invult, zullen we uw input gebruiken om Privacy Pro voor alle abonnees te verbeteren.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Enquête starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&decLang=dutch",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        13
+      ],
+      "exclusionRules": [
+        3
+      ]
+    },
+    {
+      "id": "ios_privacy_pro_subscriber_survey_it",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Cosa ne pensa di Privacy Pro?",
+        "descriptionText": "Se completa il nostro breve sondaggio, utilizzeremo il suo contributo per migliorare Privacy Pro per tutti gli abbonati.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Inizia l'indagine",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&decLang=italian",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        14
+      ],
+      "exclusionRules": [
+        3
+      ]
+    },
+    {
+      "id": "ios_privacy_pro_subscriber_survey_es",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "¿Qué opina del producto Privacy Pro?",
+        "descriptionText": "Si completa nuestra breve encuesta, utilizaremos sus comentarios para mejorar Privacy Pro para todos los suscriptores.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Empezar encuesta",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&decLang=spanish_eu",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        15
+      ],
+      "exclusionRules": [
+        3
+      ]
+    },
+    {
+      "id": "ios_privacy_pro_subscriber_survey_sv",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Vad tycker du om Privacy Pro?",
+        "descriptionText": "Om du fyller i vår korta enkät kommer vi att använda dina synpunkter för att förbättra Privacy Pro för alla prenumeranter.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Starta enkät",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/ios_privacypro_subscribersurvey?list=3&decLang=swedish",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [
+        16
+      ],
+      "exclusionRules": [
+        3
+      ]
     }
   ],
   "rules": [
@@ -370,6 +508,162 @@
         },
         "pproSubscriptionStatus": {
           "value": ["expiring"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": [
+            "sv-SE"
+          ]
+        }
+      }
+    },
+    {
+      "id": 11,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": [
+            "fr-FR",
+            "fr-CA",
+            "fr-BE",
+            "fr-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 12,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": [
+            "de-DE",
+            "de-AT",
+            "de-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 13,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": [
+            "nl-NL",
+            "nl-BE"
+          ]
+        }
+      }
+    },
+    {
+      "id": 14,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": [
+            "it-IT"
+          ]
+        }
+      }
+    },
+    {
+      "id": 15,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "7.128.0.1"
+        },
+        "locale": {
+          "value": [
+            "es-ES"
+          ]
+        }
+      }
+    },
+    {
+      "id": 16,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
         },
         "appVersion": {
           "min": "7.128.0.1"

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -471,7 +471,7 @@
       }
     },
     {
-      "id": 16,
+      "id": 17,
       "attributes": {
         "pproSubscriber": {
           "value": true

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -473,6 +473,9 @@
         "pproSubscriber": {
           "value": true
         },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
         "pproSubscriptionStatus": {
           "value": ["expiring"]
         },
@@ -498,6 +501,9 @@
         "pproSubscriber": {
           "value": true
         },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
         "pproSubscriptionStatus": {
           "value": ["expiring"]
         },
@@ -522,6 +528,9 @@
         "pproSubscriber": {
           "value": true
         },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
         "pproSubscriptionStatus": {
           "value": ["expiring"]
         },
@@ -545,6 +554,9 @@
         "pproSubscriber": {
           "value": true
         },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
         "pproSubscriptionStatus": {
           "value": ["expiring"]
         },
@@ -566,6 +578,9 @@
       "attributes": {
         "pproSubscriber": {
           "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
           "value": ["expiring"]

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -105,12 +105,11 @@
       },
       "matchingRules": [10]
     },
-
     {
       "id": "macos_privacy_pro_sparkle_exit_survey_translated_fr",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Pourquoi avez-vous annulé Privacy Pro?",
+        "titleText": "Vous avez arrêté votre abonnement ? Dites-nous tout.",
         "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Lancer le sondage",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -106,7 +106,7 @@
       "matchingRules": [10]
     },
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated_fr",
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Vous avez arrêté votre abonnement ? Dites-nous tout.",
@@ -125,7 +125,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated_de",
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Warum haben Sie Privacy Pro gekündigt?",
@@ -144,7 +144,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated_nl",
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waarom heeft u Privacy Pro opgezegd?",
@@ -163,7 +163,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated_it",
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Ci dica perché ha lasciato Privacy Pro",
@@ -182,7 +182,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated_es",
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cuéntenos por qué dejó Privacy Pro",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -148,7 +148,7 @@
       "id": "macos_privacy_pro_sparkle_exit_survey_translated_nl",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Vertel ons waarom je Privacy Pro hebt verlaten",
+        "titleText": "Waarom heeft u Privacy Pro opgezegd?",
         "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u ons Privacy Pro voor alle abonnees te verbeteren.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Enquête starten",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -124,6 +124,25 @@
       },
       "matchingRules": [13],
       "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Warum haben Sie Privacy Pro gekündigt?",
+        "descriptionText": "Durch Teilnahme an unserer kurzen Umfrage helfen Sie uns, Privacy Pro für alle Abonnenten zu verbessern.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Umfrage starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=german",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [14],
+      "exclusionRules": [5, 7]
     }
   ],
   "rules": [
@@ -321,6 +340,30 @@
             "fr-CA",
             "fr-BE",
             "fr-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 14,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 10
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "de-DE",
+            "de-AT",
+            "de-CH"
           ]
         }
       }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -192,7 +192,7 @@
         "primaryActionText": "Empezar encuesta",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=spanish",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=spanish_eu",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -186,8 +186,8 @@
       "id": "macos_privacy_pro_sparkle_exit_survey_translated_es",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Cuéntanos por qué dejaste Privacy Pro",
-        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudarás a mejorar Privacy Pro para todos los suscriptores.",
+        "titleText": "Cuéntenos por qué dejó Privacy Pro",
+        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudará a mejorar Privacy Pro para todos los suscriptores.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Empezar encuesta",
         "primaryAction": {

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -154,13 +154,32 @@
         "primaryActionText": "Enquête starten",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=german",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=dutch",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
         }
       },
       "matchingRules": [15],
+      "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated_sv",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Berätta varför du lämnade Privacy Pro",
+        "descriptionText": "Genom att svara på vår korta enkät hjälper du oss att förbättra Privacy Pro för alla prenumeranter.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Starta undersökning",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=swedish",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [16],
       "exclusionRules": [5, 7]
     }
   ],
@@ -406,6 +425,28 @@
           "value": [
             "nl-NL",
             "nl-BE"
+          ]
+        }
+      }
+    },
+    {
+      "id": 16,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 10
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "sv-SE"
           ]
         }
       }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -113,7 +113,7 @@
         "titleText": "Pourquoi avez-vous annulé Privacy Pro?",
         "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
         "placeholder": "PrivacyShield",
-        "primaryActionText": "Démarrer l'enquête",
+        "primaryActionText": "Lancer le sondage",
         "primaryAction": {
           "type": "survey",
           "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=french",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -204,7 +204,7 @@
       "id": "macos_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Faites-nous part de votre avis sur Privacy Pro",
+        "titleText": "Faites-nous part de votre avis sur Privacy Pro",
         "descriptionText": "En répondant à notre court sondage, vous contribuerez à l'amélioration de Privacy Pro pour l'ensemble de nos abonnés.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Lancer le sondage",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -164,16 +164,16 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated_sv",
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated_it",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Berätta varför du lämnade Privacy Pro",
-        "descriptionText": "Genom att svara på vår korta enkät hjälper du oss att förbättra Privacy Pro för alla prenumeranter.",
+        "titleText": "Dicci perché hai lasciato Privacy Pro",
+        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterai a migliorare Privacy Pro per tutti gli abbonati.",
         "placeholder": "PrivacyShield",
-        "primaryActionText": "Starta undersökning",
+        "primaryActionText": "Inizia l'indagine",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=swedish",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=italian",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -446,7 +446,7 @@
         },
         "locale": {
           "value": [
-            "sv-SE"
+            "it-IT"
           ]
         }
       }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -181,6 +181,25 @@
       },
       "matchingRules": [16],
       "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated_es",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Cuéntanos por qué dejaste Privacy Pro",
+        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudarás a mejorar Privacy Pro para todos los suscriptores.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Empezar encuesta",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=spanish",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [17],
+      "exclusionRules": [5, 7]
     }
   ],
   "rules": [
@@ -447,6 +466,28 @@
         "locale": {
           "value": [
             "it-IT"
+          ]
+        }
+      }
+    },
+    {
+      "id": 16,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 10
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "es-ES"
           ]
         }
       }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -388,7 +388,7 @@
       }
     },
     {
-      "id": 14,
+      "id": 15,
       "attributes": {
         "pproSubscriber": {
           "value": true

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -115,7 +115,7 @@
         "primaryActionText": "Lancer le sondage",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=french",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=french&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -134,7 +134,7 @@
         "primaryActionText": "Umfrage starten",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=german",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=german&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -153,7 +153,7 @@
         "primaryActionText": "Enquête starten",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=dutch",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=dutch&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -172,7 +172,7 @@
         "primaryActionText": "Inizia l'indagine",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=italian",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=italian&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -191,7 +191,7 @@
         "primaryActionText": "Empezar encuesta",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=spanish_eu",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=spanish_eu&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -210,7 +210,7 @@
         "primaryActionText": "Lancer le sondage",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=french",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=french&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -229,7 +229,7 @@
         "primaryActionText": "Umfrage starten",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=german",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=german&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -248,7 +248,7 @@
         "primaryActionText": "Enquête starten",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=dutch",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=dutch&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -267,7 +267,7 @@
         "primaryActionText": "Inizia l'indagine",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=italian",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=italian&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }
@@ -286,7 +286,7 @@
         "primaryActionText": "Empezar encuesta",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=spanish_eu",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=spanish_eu&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
           }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -106,7 +106,7 @@
       "matchingRules": [10]
     },
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
+      "id": "macos_privacy_pro_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Vous avez arrêté votre abonnement ? Dites-nous tout.",
@@ -125,7 +125,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
+      "id": "macos_privacy_pro_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Warum haben Sie Privacy Pro gekündigt?",
@@ -144,7 +144,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
+      "id": "macos_privacy_pro_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waarom heeft u Privacy Pro opgezegd?",
@@ -163,7 +163,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
+      "id": "macos_privacy_pro_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Ci dica perché ha lasciato Privacy Pro",
@@ -182,7 +182,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
+      "id": "macos_privacy_pro_exit_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cuéntenos por qué dejó Privacy Pro",
@@ -201,7 +201,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_sparkle_subscriber_survey_translated_fr",
+      "id": "macos_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Faites-nous part de votre avis sur Privacy Pro",
@@ -220,7 +220,7 @@
       "exclusionRules": [5, 6, 8]
     },
     {
-      "id": "macos_privacy_pro_sparkle_subscriber_survey_translated_de",
+      "id": "macos_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Was halten Sie von Privacy Pro?",
@@ -239,7 +239,7 @@
       "exclusionRules": [5, 6, 8]
     },
     {
-      "id": "macos_privacy_pro_sparkle_subscriber_survey_translated_nl",
+      "id": "macos_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waar denkt u aan bij Privacy Pro",
@@ -258,7 +258,7 @@
       "exclusionRules": [5, 6, 8]
     },
     {
-      "id": "macos_privacy_pro_sparkle_subscriber_survey_translated_it",
+      "id": "macos_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cosa ne pensa di Privacy Pro?",
@@ -277,7 +277,7 @@
       "exclusionRules": [5, 6, 8]
     },
     {
-      "id": "macos_privacy_pro_sparkle_subscriber_survey_translated_es",
+      "id": "macos_privacy_pro_subscriber_survey_translated",
       "content": {
         "messageType": "big_single_action",
         "titleText": "¿Qué opina del producto Privacy Pro?",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -20,82 +20,6 @@
       "matchingRules": [12]
     },
     {
-      "id": "macos_privacy_pro_app_store_exit_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Tell Us Why You Left Privacy Pro",
-        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&build=appStore",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [1],
-      "exclusionRules": [5, 7]
-    },
-    {
-      "id": "macos_privacy_pro_sparkle_exit_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Tell Us Why You Left Privacy Pro",
-        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&build=sparkle",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [2],
-      "exclusionRules": [5, 7]
-    },
-    {
-      "id": "macos_privacy_pro_app_store_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&build=appStore",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [3],
-      "exclusionRules": [5, 6, 8]
-    },
-    {
-      "id": "macos_privacy_pro_sparkle_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&build=sparkle",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [4],
-      "exclusionRules": [5, 6, 8]
-    },
-    {
       "id": "macos_switch_to_manual_updates",
       "content": {
         "messageType": "medium",
@@ -107,9 +31,46 @@
     },
 
 
-
     {
-      "id": "macos_privacy_pro_exit_survey_translated",
+      "id": "macos_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Why You Left Privacy Pro",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&ppro_region=us",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [1],
+      "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Why You Left Privacy Pro",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [3],
+      "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Vous avez arrêté votre abonnement ? Dites-nous tout.",
@@ -128,7 +89,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_exit_survey_translated",
+      "id": "macos_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Warum haben Sie Privacy Pro gekündigt?",
@@ -147,7 +108,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_exit_survey_translated",
+      "id": "macos_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waarom heeft u Privacy Pro opgezegd?",
@@ -166,7 +127,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_exit_survey_translated",
+      "id": "macos_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Ci dica perché ha lasciato Privacy Pro",
@@ -185,7 +146,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_exit_survey_translated",
+      "id": "macos_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cuéntenos por qué dejó Privacy Pro",
@@ -205,9 +166,46 @@
     },
 
 
-
     {
-      "id": "macos_privacy_pro_subscriber_survey_translated",
+      "id": "macos_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Your Thoughts on Privacy Pro",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&ppro_region=us",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [2],
+      "exclusionRules": [5, 6, 8]
+    },
+    {
+      "id": "macos_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Your Thoughts on Privacy Pro",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [4],
+      "exclusionRules": [5, 6, 8]
+    },
+    {
+      "id": "macos_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Faites-nous part de votre avis sur Privacy Pro",
@@ -226,7 +224,7 @@
       "exclusionRules": [5, 6, 8]
     },
     {
-      "id": "macos_privacy_pro_subscriber_survey_translated",
+      "id": "macos_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Was halten Sie von Privacy Pro?",
@@ -245,7 +243,7 @@
       "exclusionRules": [5, 6, 8]
     },
     {
-      "id": "macos_privacy_pro_subscriber_survey_translated",
+      "id": "macos_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waar denkt u aan bij Privacy Pro",
@@ -264,7 +262,7 @@
       "exclusionRules": [5, 6, 8]
     },
     {
-      "id": "macos_privacy_pro_subscriber_survey_translated",
+      "id": "macos_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cosa ne pensa di Privacy Pro?",
@@ -283,7 +281,7 @@
       "exclusionRules": [5, 6, 8]
     },
     {
-      "id": "macos_privacy_pro_subscriber_survey_translated",
+      "id": "macos_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
         "titleText": "¿Qué opina del producto Privacy Pro?",
@@ -310,7 +308,7 @@
           "value": true
         },
         "pproPurchasePlatform": {
-          "value": ["apple"]
+          "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
           "value": ["expiring"]
@@ -320,9 +318,6 @@
         },
         "appVersion": {
           "min": "1.101.0"
-        },
-        "installedMacAppStore": {
-          "value": true
         },
         "locale": {
           "value": ["en-US"]
@@ -331,32 +326,6 @@
     },
     {
       "id": 2,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproPurchasePlatform": {
-          "value": ["stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["expiring"]
-        },
-        "pproDaysUntilExpiryOrRenewal": {
-          "max": 10
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "installedMacAppStore": {
-          "value": false
-        },
-        "locale": {
-          "value": ["en-US"]
-        }
-      }
-    },
-    {
-      "id": 3,
       "attributes": {
         "pproSubscriber": {
           "value": true
@@ -373,11 +342,31 @@
         "appVersion": {
           "min": "1.101.0"
         },
-        "installedMacAppStore": {
-          "value": true
-        },
         "locale": {
           "value": ["en-US"]
+        }
+      }
+    },
+    {
+      "id": 3,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 10
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": ["en-CA", "en-UK"]
         }
       }
     },
@@ -399,11 +388,8 @@
         "appVersion": {
           "min": "1.101.0"
         },
-        "installedMacAppStore": {
-          "value": false
-        },
         "locale": {
-          "value": ["en-US"]
+          "value": ["en-CA", "en-UK"]
         }
       }
     },
@@ -423,7 +409,11 @@
       "id": 6,
       "attributes": {
         "interactedWithMessage": {
-          "value": ["macos_privacy_pro_subscriber_survey_1"]
+          "value": [
+            "macos_privacy_pro_subscriber_survey_1",
+            "macos_privacy_pro_sparkle_subscriber_survey_1",
+            "macos_privacy_pro_app_store_subscriber_survey_1"
+          ]
         }
       }
     },
@@ -475,6 +465,8 @@
         }
       }
     },
+
+
 
     {
       "id": 13,
@@ -610,9 +602,6 @@
         "appVersion": {
           "min": "1.101.0"
         },
-        "installedMacAppStore": {
-          "value": false
-        },
         "locale": {
           "value": [
             "fr-FR",
@@ -641,9 +630,6 @@
         "appVersion": {
           "min": "1.101.0"
         },
-        "installedMacAppStore": {
-          "value": false
-        },
         "locale": {
           "value": [
             "de-DE",
@@ -671,9 +657,6 @@
         "appVersion": {
           "min": "1.101.0"
         },
-        "installedMacAppStore": {
-          "value": false
-        },
         "locale": {
           "value": [
             "nl-NL",
@@ -700,9 +683,6 @@
         "appVersion": {
           "min": "1.101.0"
         },
-        "installedMacAppStore": {
-          "value": false
-        },
         "locale": {
           "value": [
             "it-IT"
@@ -727,9 +707,6 @@
         },
         "appVersion": {
           "min": "1.101.0"
-        },
-        "installedMacAppStore": {
-          "value": false
         },
         "locale": {
           "value": [

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -167,8 +167,8 @@
       "id": "macos_privacy_pro_sparkle_exit_survey_translated_it",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Dicci perché hai lasciato Privacy Pro",
-        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterai a migliorare Privacy Pro per tutti gli abbonati.",
+        "titleText": "Ci dica perché ha lasciato Privacy Pro",
+        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterà a migliorare Privacy Pro per tutti gli abbonati.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Inizia l'indagine",
         "primaryAction": {

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -105,6 +105,9 @@
       },
       "matchingRules": [10]
     },
+
+
+
     {
       "id": "macos_privacy_pro_exit_survey_translated",
       "content": {
@@ -200,6 +203,9 @@
       "matchingRules": [17],
       "exclusionRules": [5, 7]
     },
+
+
+
     {
       "id": "macos_privacy_pro_subscriber_survey_translated",
       "content": {

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 17,
+  "version": 18,
   "messages": [
     {
       "id": "macos_permanent_survey_tab_bar",
@@ -104,6 +104,26 @@
         "placeholder": "CriticalUpdate"
       },
       "matchingRules": [10]
+    },
+
+    {
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Pourquoi avez-vous annulé Privacy Pro?",
+        "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Démarrer l'enquête",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=french",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [13],
+      "exclusionRules": [5, 7]
     }
   ],
   "rules": [
@@ -275,6 +295,32 @@
             "en-CA",
             "en-GB",
             "en-AU"
+          ]
+        }
+      }
+    },
+
+    {
+      "id": 13,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 10
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "fr-FR",
+            "fr-CA",
+            "fr-BE",
+            "fr-CH"
           ]
         }
       }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -199,6 +199,101 @@
       },
       "matchingRules": [17],
       "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_sparkle_subscriber_survey_translated_fr",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Faites-nous part de votre avis sur Privacy Pro",
+        "descriptionText": "En répondant à notre court sondage, vous contribuerez à l'amélioration de Privacy Pro pour l'ensemble de nos abonnés.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Lancer le sondage",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=french",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [18],
+      "exclusionRules": [5, 6, 8]
+    },
+    {
+      "id": "macos_privacy_pro_sparkle_subscriber_survey_translated_de",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Was halten Sie von Privacy Pro?",
+        "descriptionText": "Wenn Sie an unserer kurzen Umfrage teilnehmen, werden wir Ihre Eingaben verwenden, um Privacy Pro für alle Abonnenten zu verbessern.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Umfrage starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=german",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [19],
+      "exclusionRules": [5, 6, 8]
+    },
+    {
+      "id": "macos_privacy_pro_sparkle_subscriber_survey_translated_nl",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Waar denkt u aan bij Privacy Pro",
+        "descriptionText": "Als u onze korte enquête invult, zullen we uw input gebruiken om Privacy Pro voor alle abonnees te verbeteren.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Enquête starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=dutch",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [20],
+      "exclusionRules": [5, 6, 8]
+    },
+    {
+      "id": "macos_privacy_pro_sparkle_subscriber_survey_translated_it",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Cosa ne pensa di Privacy Pro?",
+        "descriptionText": "Se completa il nostro breve sondaggio, utilizzeremo il suo contributo per migliorare Privacy Pro per tutti gli abbonati.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Inizia l'indagine",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=italian",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [21],
+      "exclusionRules": [5, 6, 8]
+    },
+    {
+      "id": "macos_privacy_pro_sparkle_subscriber_survey_translated_es",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "¿Qué opina del producto Privacy Pro?",
+        "descriptionText": "Si completa nuestra breve encuesta, utilizaremos sus comentarios para mejorar Privacy Pro para todos los suscriptores.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Empezar encuesta",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=spanish_eu",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [22],
+      "exclusionRules": [5, 6, 8]
     }
   ],
   "rules": [
@@ -483,6 +578,152 @@
         },
         "appVersion": {
           "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "es-ES"
+          ]
+        }
+      }
+    },
+    {
+      "id": 18,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "installedMacAppStore": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "fr-FR",
+            "fr-CA",
+            "fr-BE",
+            "fr-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 19,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "installedMacAppStore": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "de-DE",
+            "de-AT",
+            "de-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 20,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "installedMacAppStore": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "nl-NL",
+            "nl-BE"
+          ]
+        }
+      }
+    },
+    {
+      "id": 21,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "installedMacAppStore": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "it-IT"
+          ]
+        }
+      }
+    },
+    {
+      "id": 22,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "installedMacAppStore": {
+          "value": false
         },
         "locale": {
           "value": [

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -107,7 +107,7 @@
     },
 
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated_fr",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Pourquoi avez-vous annulé Privacy Pro?",
@@ -126,7 +126,7 @@
       "exclusionRules": [5, 7]
     },
     {
-      "id": "macos_privacy_pro_sparkle_exit_survey_translated",
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated_de",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Warum haben Sie Privacy Pro gekündigt?",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -24,7 +24,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Why You Left Privacy Pro",
-        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
@@ -43,7 +43,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Why You Left Privacy Pro",
-        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
@@ -62,7 +62,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
@@ -81,7 +81,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
@@ -111,7 +111,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Pourquoi avez-vous annulé Privacy Pro?",
-        "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
+        "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Démarrer l'enquête",
         "primaryAction": {
@@ -130,7 +130,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Warum haben Sie Privacy Pro gekündigt?",
-        "descriptionText": "Durch Teilnahme an unserer kurzen Umfrage helfen Sie uns, Privacy Pro für alle Abonnenten zu verbessern.",
+        "descriptionText": "Durch Teilnahme an unserer kurzen Umfrage helfen Sie uns, Privacy Pro für alle Abonnenten zu verbessern.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Umfrage starten",
         "primaryAction": {
@@ -149,7 +149,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waarom heeft u Privacy Pro opgezegd?",
-        "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u ons Privacy Pro voor alle abonnees te verbeteren.",
+        "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u ons Privacy Pro voor alle abonnees te verbeteren.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Enquête starten",
         "primaryAction": {
@@ -168,7 +168,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Ci dica perché ha lasciato Privacy Pro",
-        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterà a migliorare Privacy Pro per tutti gli abbonati.",
+        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterà a migliorare Privacy Pro per tutti gli abbonati.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Inizia l'indagine",
         "primaryAction": {
@@ -187,7 +187,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cuéntanos por qué dejaste Privacy Pro",
-        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudarás a mejorar Privacy Pro para todos los suscriptores.",
+        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudarás a mejorar Privacy Pro para todos los suscriptores.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Empezar encuesta",
         "primaryAction": {

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -143,6 +143,25 @@
       },
       "matchingRules": [14],
       "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_sparkle_exit_survey_translated_nl",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Vertel ons waarom je Privacy Pro hebt verlaten",
+        "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u ons Privacy Pro voor alle abonnees te verbeteren.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Enquête starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=german",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [15],
+      "exclusionRules": [5, 7]
     }
   ],
   "rules": [
@@ -364,6 +383,29 @@
             "de-DE",
             "de-AT",
             "de-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 14,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 10
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "nl-NL",
+            "nl-BE"
           ]
         }
       }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -2,36 +2,6 @@
   "version": 18,
   "messages": [
     {
-      "id": "macos_permanent_survey_tab_bar",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help Us Improve!",
-        "descriptionText": "We really want to know which features would make our browser better.",
-        "placeholder": "Announce",
-        "primaryActionText": "Tell Us What You Think",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/241004?list=2",
-          "additionalParameters": {
-            "queryParams": "delta;var;osv;ddgv"
-          }
-        }
-      },
-      "matchingRules": [12]
-    },
-    {
-      "id": "macos_switch_to_manual_updates",
-      "content": {
-        "messageType": "medium",
-        "titleText": "Automatic Update Failed",
-        "descriptionText": "To get the latest version of DuckDuckGo  \n1\\. Go to **Settings > About**  \n2\\. Select **Check for updates but let me choose to install them**  \n3\\. Click **Restart To Update**",
-        "placeholder": "CriticalUpdate"
-      },
-      "matchingRules": [10]
-    },
-
-
-    {
       "id": "macos_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
@@ -298,6 +268,35 @@
       },
       "matchingRules": [22],
       "exclusionRules": [5, 6, 8]
+    },
+
+    {
+      "id": "macos_permanent_survey_tab_bar",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve!",
+        "descriptionText": "We really want to know which features would make our browser better.",
+        "placeholder": "Announce",
+        "primaryActionText": "Tell Us What You Think",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/241004?list=2",
+          "additionalParameters": {
+            "queryParams": "delta;var;osv;ddgv"
+          }
+        }
+      },
+      "matchingRules": [12]
+    },
+    {
+      "id": "macos_switch_to_manual_updates",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Automatic Update Failed",
+        "descriptionText": "To get the latest version of DuckDuckGo  \n1\\. Go to **Settings > About**  \n2\\. Select **Check for updates but let me choose to install them**  \n3\\. Click **Restart To Update**",
+        "placeholder": "CriticalUpdate"
+      },
+      "matchingRules": [10]
     }
   ],
   "rules": [


### PR DESCRIPTION
This PR covers the iOS and macOS survey translation for Privacy Pro. The new surveys reuse the same message IDs as the English messages, since we want to avoid showing an invitation to the same user multiple times, even if they change their device language.

The exact changes are:

**iOS**:
* Added non-US English exit survey
* Added non-US English subscriber survey
* Added French exit & subscriber surveys
* Added German exit & subscriber surveys
* Added Dutch exit & subscriber surveys
* Added Italian exit & subscriber surveys
* Added Spanish exit & subscriber surveys
* Added Swedish exit & subscriber surveys

**macOS:**
* Added non-US English exit survey
* Added non-US English subscriber survey
* Added French exit & subscriber surveys
* Added German exit & subscriber surveys
* Added Dutch exit & subscriber surveys
* Added Italian exit & subscriber surveys
* Added Spanish exit & subscriber surveys
* Note: no Swedish survey has been added for macOS as the app isn't localized into that yet

**Testing steps:**
Overall this change is just adding localized versions of the existing surveys. The message ID is reused between messages so that users who see a message and then change language should not see it again.

To test this, first you need to get your device into either either subscriber or expiring states, you can see https://github.com/duckduckgo/remote-messaging-config/pull/58 and https://github.com/duckduckgo/remote-messaging-config/pull/73 for previous instructions on how to do this.

After that, simply test the languages being added by changing the app's scheme language setting and confirming that the messages show up. It's expected that if your device is showing one language and you then change it, you may not see the new language until RMF refreshes - this is considered acceptable.