### PR TITLE
Add translated macOS Privacy Pro surveys

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -365,7 +365,7 @@
           "min": "1.101.0"
         },
         "locale": {
-          "value": ["en-CA", "en-UK"]
+          "value": ["en-CA", "en-GB"]
         }
       }
     },

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -178,7 +178,7 @@
       "id": "macos_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Faites-nous part de votre avis sur Privacy Pro",
+        "titleText": "Faites-nous part de votre avis sur Privacy Pro",
         "descriptionText": "En répondant à notre court sondage, vous contribuerez à l'amélioration de Privacy Pro pour l'ensemble de nos abonnés.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Lancer le sondage",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -388,7 +388,7 @@
           "min": "1.101.0"
         },
         "locale": {
-          "value": ["en-CA", "en-UK"]
+          "value": ["en-CA", "en-GB"]
         }
       }
     },

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,6 +1,275 @@
 {
-  "version": 17,
+  "version": 18,
   "messages": [
+    {
+      "id": "macos_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Why You Left Privacy Pro",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&ppro_region=us",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [1],
+      "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Why You Left Privacy Pro",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [3],
+      "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Vous avez arrêté votre abonnement ? Dites-nous tout.",
+        "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Lancer le sondage",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=french&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [13],
+      "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Warum haben Sie Privacy Pro gekündigt?",
+        "descriptionText": "Durch Teilnahme an unserer kurzen Umfrage helfen Sie uns, Privacy Pro für alle Abonnenten zu verbessern.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Umfrage starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=german&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [14],
+      "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Waarom heeft u Privacy Pro opgezegd?",
+        "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u ons Privacy Pro voor alle abonnees te verbeteren.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Enquête starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=dutch&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [15],
+      "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Ci dica perché ha lasciato Privacy Pro",
+        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterà a migliorare Privacy Pro per tutti gli abbonati.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Inizia l'indagine",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=italian&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [16],
+      "exclusionRules": [5, 7]
+    },
+    {
+      "id": "macos_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Cuéntenos por qué dejó Privacy Pro",
+        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudará a mejorar Privacy Pro para todos los suscriptores.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Empezar encuesta",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=spanish_eu&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [17],
+      "exclusionRules": [5, 7]
+    },
+
+
+    {
+      "id": "macos_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Your Thoughts on Privacy Pro",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&ppro_region=us",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [2],
+      "exclusionRules": [5, 6, 8]
+    },
+    {
+      "id": "macos_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Your Thoughts on Privacy Pro",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [4],
+      "exclusionRules": [5, 6, 8]
+    },
+    {
+      "id": "macos_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Faites-nous part de votre avis sur Privacy Pro",
+        "descriptionText": "En répondant à notre court sondage, vous contribuerez à l'amélioration de Privacy Pro pour l'ensemble de nos abonnés.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Lancer le sondage",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=french&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [18],
+      "exclusionRules": [5, 6, 8]
+    },
+    {
+      "id": "macos_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Was halten Sie von Privacy Pro?",
+        "descriptionText": "Wenn Sie an unserer kurzen Umfrage teilnehmen, werden wir Ihre Eingaben verwenden, um Privacy Pro für alle Abonnenten zu verbessern.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Umfrage starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=german&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [19],
+      "exclusionRules": [5, 6, 8]
+    },
+    {
+      "id": "macos_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Waar denkt u aan bij Privacy Pro",
+        "descriptionText": "Als u onze korte enquête invult, zullen we uw input gebruiken om Privacy Pro voor alle abonnees te verbeteren.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Enquête starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=dutch&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [20],
+      "exclusionRules": [5, 6, 8]
+    },
+    {
+      "id": "macos_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Cosa ne pensa di Privacy Pro?",
+        "descriptionText": "Se completa il nostro breve sondaggio, utilizzeremo il suo contributo per migliorare Privacy Pro per tutti gli abbonati.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Inizia l'indagine",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=italian&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [21],
+      "exclusionRules": [5, 6, 8]
+    },
+    {
+      "id": "macos_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "¿Qué opina del producto Privacy Pro?",
+        "descriptionText": "Si completa nuestra breve encuesta, utilizaremos sus comentarios para mejorar Privacy Pro para todos los suscriptores.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Empezar encuesta",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=spanish_eu&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
+          }
+        }
+      },
+      "matchingRules": [22],
+      "exclusionRules": [5, 6, 8]
+    },
+
     {
       "id": "macos_permanent_survey_tab_bar",
       "content": {
@@ -18,82 +287,6 @@
         }
       },
       "matchingRules": [12]
-    },
-    {
-      "id": "macos_privacy_pro_app_store_exit_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Tell Us Why You Left Privacy Pro",
-        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&build=appStore",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [1],
-      "exclusionRules": [5, 7]
-    },
-    {
-      "id": "macos_privacy_pro_sparkle_exit_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Tell Us Why You Left Privacy Pro",
-        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&build=sparkle",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [2],
-      "exclusionRules": [5, 7]
-    },
-    {
-      "id": "macos_privacy_pro_app_store_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&build=appStore",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [3],
-      "exclusionRules": [5, 6, 8]
-    },
-    {
-      "id": "macos_privacy_pro_sparkle_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&build=sparkle",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [4],
-      "exclusionRules": [5, 6, 8]
     },
     {
       "id": "macos_switch_to_manual_updates",
@@ -114,7 +307,7 @@
           "value": true
         },
         "pproPurchasePlatform": {
-          "value": ["apple"]
+          "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
           "value": ["expiring"]
@@ -124,9 +317,6 @@
         },
         "appVersion": {
           "min": "1.101.0"
-        },
-        "installedMacAppStore": {
-          "value": true
         },
         "locale": {
           "value": ["en-US"]
@@ -135,32 +325,6 @@
     },
     {
       "id": 2,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproPurchasePlatform": {
-          "value": ["stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["expiring"]
-        },
-        "pproDaysUntilExpiryOrRenewal": {
-          "max": 10
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "installedMacAppStore": {
-          "value": false
-        },
-        "locale": {
-          "value": ["en-US"]
-        }
-      }
-    },
-    {
-      "id": 3,
       "attributes": {
         "pproSubscriber": {
           "value": true
@@ -177,11 +341,31 @@
         "appVersion": {
           "min": "1.101.0"
         },
-        "installedMacAppStore": {
-          "value": true
-        },
         "locale": {
           "value": ["en-US"]
+        }
+      }
+    },
+    {
+      "id": 3,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 10
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": ["en-CA", "en-UK"]
         }
       }
     },
@@ -203,11 +387,8 @@
         "appVersion": {
           "min": "1.101.0"
         },
-        "installedMacAppStore": {
-          "value": false
-        },
         "locale": {
-          "value": ["en-US"]
+          "value": ["en-CA", "en-UK"]
         }
       }
     },
@@ -227,7 +408,11 @@
       "id": 6,
       "attributes": {
         "interactedWithMessage": {
-          "value": ["macos_privacy_pro_subscriber_survey_1"]
+          "value": [
+            "macos_privacy_pro_subscriber_survey_1",
+            "macos_privacy_pro_sparkle_subscriber_survey_1",
+            "macos_privacy_pro_app_store_subscriber_survey_1"
+          ]
         }
       }
     },
@@ -275,6 +460,271 @@
             "en-CA",
             "en-GB",
             "en-AU"
+          ]
+        }
+      }
+    },
+
+
+
+    {
+      "id": 13,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 10
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "fr-FR",
+            "fr-CA",
+            "fr-BE",
+            "fr-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 14,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 10
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "de-DE",
+            "de-AT",
+            "de-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 15,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 10
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "nl-NL",
+            "nl-BE"
+          ]
+        }
+      }
+    },
+    {
+      "id": 16,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 10
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "it-IT"
+          ]
+        }
+      }
+    },
+    {
+      "id": 17,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["expiring"]
+        },
+        "pproDaysUntilExpiryOrRenewal": {
+          "max": 10
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "es-ES"
+          ]
+        }
+      }
+    },
+    {
+      "id": 18,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "fr-FR",
+            "fr-CA",
+            "fr-BE",
+            "fr-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 19,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "de-DE",
+            "de-AT",
+            "de-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 20,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "nl-NL",
+            "nl-BE"
+          ]
+        }
+      }
+    },
+    {
+      "id": 21,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "it-IT"
+          ]
+        }
+      }
+    },
+    {
+      "id": 22,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": ["apple", "stripe"]
+        },
+        "pproSubscriptionStatus": {
+          "value": ["active"]
+        },
+        "appVersion": {
+          "min": "1.101.0"
+        },
+        "locale": {
+          "value": [
+            "es-ES"
           ]
         }
       }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -310,7 +310,7 @@
           "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
-          "value": ["expiring"]
+          "value": ["expiring", "expired"]
         },
         "pproDaysUntilExpiryOrRenewal": {
           "max": 10
@@ -356,7 +356,7 @@
           "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
-          "value": ["expiring"]
+          "value": ["expiring", "expired"]
         },
         "pproDaysUntilExpiryOrRenewal": {
           "max": 10
@@ -477,7 +477,7 @@
           "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
-          "value": ["expiring"]
+          "value": ["expiring", "expired"]
         },
         "pproDaysUntilExpiryOrRenewal": {
           "max": 10
@@ -505,7 +505,7 @@
           "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
-          "value": ["expiring"]
+          "value": ["expiring", "expired"]
         },
         "pproDaysUntilExpiryOrRenewal": {
           "max": 10
@@ -532,7 +532,7 @@
           "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
-          "value": ["expiring"]
+          "value": ["expiring", "expired"]
         },
         "pproDaysUntilExpiryOrRenewal": {
           "max": 10
@@ -558,7 +558,7 @@
           "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
-          "value": ["expiring"]
+          "value": ["expiring", "expired"]
         },
         "pproDaysUntilExpiryOrRenewal": {
           "max": 10
@@ -583,7 +583,7 @@
           "value": ["apple", "stripe"]
         },
         "pproSubscriptionStatus": {
-          "value": ["expiring"]
+          "value": ["expiring", "expired"]
         },
         "pproDaysUntilExpiryOrRenewal": {
           "max": 10

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -270,6 +270,7 @@
       "exclusionRules": [5, 6, 8]
     },
 
+
     {
       "id": "macos_permanent_survey_tab_bar",
       "content": {


### PR DESCRIPTION
This PR covers the macOS survey translation for Privacy Pro. The new surveys reuse the same message IDs as the English messages, since we want to avoid showing an invitation to the same user multiple times, even if they change their device language.

This PR replaces https://github.com/duckduckgo/remote-messaging-config/pull/155, which contains the exact same changes except included iOS too - I've opted to break these changes up by platform so that we can deploy them independently.

The exact changes are:

**macOS:**
* Added non-US English exit survey
* Added non-US English subscriber survey
* Added French exit & subscriber surveys
* Added German exit & subscriber surveys
* Added Dutch exit & subscriber surveys
* Added Italian exit & subscriber surveys
* Added Spanish exit & subscriber surveys
* Note: no Swedish survey has been added for macOS as the app isn't localized into that yet

**Testing steps:**
Overall this change is just adding localized versions of the existing surveys. The message ID is reused between messages so that users who see a message and then change language should not see it again.

To test this, first you need to get your device into either either subscriber or expiring states, you can see https://github.com/duckduckgo/remote-messaging-config/pull/58 and https://github.com/duckduckgo/remote-messaging-config/pull/73 for previous instructions on how to do this.

After that, simply test the languages being added by changing the app's scheme language setting and confirming that the messages show up. It's expected that if your device is showing one language and you then change it, you may not see the new language until RMF refreshes - this is considered acceptable.