### PR TITLE
Add translated Android Privacy Pro surveys

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -332,7 +332,7 @@
         "primaryActionText": "Starta enkät",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=swedish",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=swedish&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
           }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -194,7 +194,7 @@
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
           }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -217,7 +217,7 @@
         "primaryActionText": "Lancer le sondage",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=french",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=french&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
           }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -6,7 +6,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Why You Left Privacy Pro",
-        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers. ",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -309,7 +309,7 @@
         "primaryActionText": "Empezar encuesta",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=spanish_eu",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=spanish_eu&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
           }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -11,7 +11,7 @@
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&ppro_region=us",
           "additionalParameters": {
             "queryParams": "var;ddgv;man;mo;av;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
           }
@@ -171,7 +171,7 @@
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&ppro_region=us",
           "additionalParameters": {
             "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
           }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -286,7 +286,7 @@
         "primaryActionText": "Inizia l'indagine",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=italian",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=italian&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
           }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -6,7 +6,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Why You Left Privacy Pro",
-        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers. ",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers. ",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
@@ -26,7 +26,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Why You Left Privacy Pro",
-        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
@@ -46,7 +46,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Vous avez arrêté votre abonnement ? Dites-nous tout.",
-        "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
+        "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Lancer le sondage",
         "primaryAction": {
@@ -66,7 +66,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Warum haben Sie Privacy Pro gekündigt?",
-        "descriptionText": "Durch Teilnahme an unserer kurzen Umfrage helfen Sie uns, Privacy Pro für alle Abonnenten zu verbessern.",
+        "descriptionText": "Durch Teilnahme an unserer kurzen Umfrage helfen Sie uns, Privacy Pro für alle Abonnenten zu verbessern.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Umfrage starten",
         "primaryAction": {
@@ -86,7 +86,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waarom heeft u Privacy Pro opgezegd?",
-        "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u ons Privacy Pro voor alle abonnees te verbeteren.",
+        "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u ons Privacy Pro voor alle abonnees te verbeteren.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Enquête starten",
         "primaryAction": {
@@ -106,7 +106,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Ci dica perché ha lasciato Privacy Pro",
-        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterà a migliorare Privacy Pro per tutti gli abbonati.",
+        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterà a migliorare Privacy Pro per tutti gli abbonati.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Inizia l'indagine",
         "primaryAction": {
@@ -126,7 +126,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cuéntenos por qué dejó Privacy Pro",
-        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudará a mejorar Privacy Pro para todos los suscriptores.",
+        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudará a mejorar Privacy Pro para todos los suscriptores.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Empezar encuesta",
         "primaryAction": {
@@ -146,7 +146,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Berätta varför du lämnade Privacy Pro",
-        "descriptionText": "Genom att svara på vår korta enkät hjälper du oss att förbättra Privacy Pro för alla prenumeranter.",
+        "descriptionText": "Genom att svara på vår korta enkät hjälper du oss att förbättra Privacy Pro för alla prenumeranter.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Starta enkät",
         "primaryAction": {
@@ -166,7 +166,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
@@ -189,7 +189,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
@@ -211,8 +211,8 @@
       "id": "android_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Faites-nous part de votre avis sur Privacy Pro",
-        "descriptionText": "En répondant à notre court sondage, vous contribuerez à l'amélioration de Privacy Pro pour l'ensemble de nos abonnés.",
+        "titleText": "Faites-nous part de votre avis sur Privacy Pro",
+        "descriptionText": "En répondant à notre court sondage, vous contribuerez à l'amélioration de Privacy Pro pour l'ensemble de nos abonnés.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Lancer le sondage",
         "primaryAction": {
@@ -235,7 +235,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Was halten Sie von Privacy Pro?",
-        "descriptionText": "Wenn Sie an unserer kurzen Umfrage teilnehmen, werden wir Ihre Eingaben verwenden, um Privacy Pro für alle Abonnenten zu verbessern.",
+        "descriptionText": "Wenn Sie an unserer kurzen Umfrage teilnehmen, werden wir Ihre Eingaben verwenden, um Privacy Pro für alle Abonnenten zu verbessern.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Umfrage starten",
         "primaryAction": {
@@ -258,7 +258,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Waar denkt u aan bij Privacy Pro",
-        "descriptionText": "Als u onze korte enquête invult, zullen we uw input gebruiken om Privacy Pro voor alle abonnees te verbeteren.",
+        "descriptionText": "Als u onze korte enquête invult, zullen we uw input gebruiken om Privacy Pro voor alle abonnees te verbeteren.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Enquête starten",
         "primaryAction": {
@@ -281,7 +281,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Cosa ne pensa di Privacy Pro?",
-        "descriptionText": "Se completa il nostro breve sondaggio, utilizzeremo il suo contributo per migliorare Privacy Pro per tutti gli abbonati.",
+        "descriptionText": "Se completa il nostro breve sondaggio, utilizzeremo il suo contributo per migliorare Privacy Pro per tutti gli abbonati.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Inizia l'indagine",
         "primaryAction": {
@@ -304,7 +304,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "¿Qué opina del producto Privacy Pro?",
-        "descriptionText": "Si completa nuestra breve encuesta, utilizaremos sus comentarios para mejorar Privacy Pro para todos los suscriptores.",
+        "descriptionText": "Si completa nuestra breve encuesta, utilizaremos sus comentarios para mejorar Privacy Pro para todos los suscriptores.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Empezar encuesta",
         "primaryAction": {
@@ -327,7 +327,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Vad tycker du om Privacy Pro?",
-        "descriptionText": "Om du fyller i vår korta enkät kommer vi att använda dina synpunkter för att förbättra Privacy Pro för alla prenumeranter.",
+        "descriptionText": "Om du fyller i vår korta enkät kommer vi att använda dina synpunkter för att förbättra Privacy Pro för alla prenumeranter.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Starta enkät",
         "primaryAction": {

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -240,7 +240,7 @@
         "primaryActionText": "Umfrage starten",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=german",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=german&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
           }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -263,7 +263,7 @@
         "primaryActionText": "Enquête starten",
         "primaryAction": {
           "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=dutch",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=dutch&ppro_region=row",
           "additionalParameters": {
             "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
           }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 44,
+  "version": 45,
   "messages": [
     {
       "id": "android_privacy_pro_exit_survey_1",
@@ -19,6 +19,146 @@
       },
       "matchingRules": [
         7
+      ]
+    },
+    {
+      "id": "android_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Why You Left Privacy Pro",
+        "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;ddgv;man;mo;av;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        17
+      ]
+    },
+    {
+      "id": "android_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Vous avez arrêté votre abonnement ? Dites-nous tout.",
+        "descriptionText": "En répondant à notre bref sondage, vous nous aiderez à améliorer Privacy Pro pour tous les abonnés.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Lancer le sondage",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=french&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;ddgv;man;mo;av;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        11
+      ]
+    },
+    {
+      "id": "android_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Warum haben Sie Privacy Pro gekündigt?",
+        "descriptionText": "Durch Teilnahme an unserer kurzen Umfrage helfen Sie uns, Privacy Pro für alle Abonnenten zu verbessern.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Umfrage starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=german&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;ddgv;man;mo;av;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        12
+      ]
+    },
+    {
+      "id": "android_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Waarom heeft u Privacy Pro opgezegd?",
+        "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u ons Privacy Pro voor alle abonnees te verbeteren.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Enquête starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=dutch&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;ddgv;man;mo;av;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        13
+      ]
+    },
+    {
+      "id": "android_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Ci dica perché ha lasciato Privacy Pro",
+        "descriptionText": "Partecipando al nostro breve sondaggio, ci aiuterà a migliorare Privacy Pro per tutti gli abbonati.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Inizia l'indagine",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=italian&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;ddgv;man;mo;av;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        14
+      ]
+    },
+    {
+      "id": "android_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Cuéntenos por qué dejó Privacy Pro",
+        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudará a mejorar Privacy Pro para todos los suscriptores.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Empezar encuesta",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=spanish_eu&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;ddgv;man;mo;av;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        15
+      ]
+    },
+    {
+      "id": "android_privacy_pro_exit_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Berätta varför du lämnade Privacy Pro",
+        "descriptionText": "Genom att svara på vår korta enkät hjälper du oss att förbättra Privacy Pro för alla prenumeranter.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Starta enkät",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=swedish&ppro_region=row",
+          "additionalParameters": {
+            "queryParams": "var;ddgv;man;mo;av;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        16
       ]
     },
     {
@@ -185,6 +325,202 @@
           "value": [
             "android_quarterly_satisfaction_survey_q4_2024",
             "android_quarterly_satisfaction_survey_1224"
+          ]
+        }
+      }
+    },
+    {
+      "id": 11,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "expiring",
+            "expired"
+          ]
+        },
+        "appVersion": {
+          "min": "5.207.0"
+        },
+        "locale": {
+          "value": [
+            "fr-FR",
+            "fr-CA",
+            "fr-BE",
+            "fr-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 12,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "expiring",
+            "expired"
+          ]
+        },
+        "appVersion": {
+          "min": "5.207.0"
+        },
+        "locale": {
+          "value": [
+            "de-DE",
+            "de-AT",
+            "de-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 13,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "expiring",
+            "expired"
+          ]
+        },
+        "appVersion": {
+          "min": "5.207.0"
+        },
+        "locale": {
+          "value": [
+            "nl-NL",
+            "nl-BE"
+          ]
+        }
+      }
+    },
+    {
+      "id": 14,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "expiring",
+            "expired"
+          ]
+        },
+        "appVersion": {
+          "min": "5.207.0"
+        },
+        "locale": {
+          "value": [
+            "it-IT"
+          ]
+        }
+      }
+    },
+    {
+      "id": 15,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "expiring",
+            "expired"
+          ]
+        },
+        "appVersion": {
+          "min": "5.207.0"
+        },
+        "locale": {
+          "value": [
+            "es-ES"
+          ]
+        }
+      }
+    },
+    {
+      "id": 16,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "expiring",
+            "expired"
+          ]
+        },
+        "appVersion": {
+          "min": "5.207.0"
+        },
+        "locale": {
+          "value": [
+            "sv-SE"
+          ]
+        }
+      }
+    },
+    {
+      "id": 17,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "expiring",
+            "expired"
+          ]
+        },
+        "appVersion": {
+          "min": "5.207.0"
+        },
+        "locale": {
+          "value": [
+            "en-GB",
+            "en-CA"
           ]
         }
       }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -185,6 +185,167 @@
       ]
     },
     {
+      "id": "android_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us Your Thoughts on Privacy Pro",
+        "descriptionText": "If you complete our brief survey, your input will help improve the Privacy Pro experience for all subscribers.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4",
+          "additionalParameters": {
+            "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        18
+      ],
+      "exclusionRules": [
+        8
+      ]
+    },
+    {
+      "id": "android_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Faites-nous part de votre avis sur Privacy Pro",
+        "descriptionText": "En répondant à notre court sondage, vous contribuerez à l'amélioration de Privacy Pro pour l'ensemble de nos abonnés.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Lancer le sondage",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=french",
+          "additionalParameters": {
+            "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        19
+      ],
+      "exclusionRules": [
+        8
+      ]
+    },
+    {
+      "id": "android_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Was halten Sie von Privacy Pro?",
+        "descriptionText": "Wenn Sie an unserer kurzen Umfrage teilnehmen, werden wir Ihre Eingaben verwenden, um Privacy Pro für alle Abonnenten zu verbessern.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Umfrage starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=german",
+          "additionalParameters": {
+            "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        20
+      ],
+      "exclusionRules": [
+        8
+      ]
+    },
+    {
+      "id": "android_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Waar denkt u aan bij Privacy Pro",
+        "descriptionText": "Als u onze korte enquête invult, zullen we uw input gebruiken om Privacy Pro voor alle abonnees te verbeteren.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Enquête starten",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=dutch",
+          "additionalParameters": {
+            "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        21
+      ],
+      "exclusionRules": [
+        8
+      ]
+    },
+    {
+      "id": "android_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Cosa ne pensa di Privacy Pro?",
+        "descriptionText": "Se completa il nostro breve sondaggio, utilizzeremo il suo contributo per migliorare Privacy Pro per tutti gli abbonati.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Inizia l'indagine",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=italian",
+          "additionalParameters": {
+            "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        22
+      ],
+      "exclusionRules": [
+        8
+      ]
+    },
+    {
+      "id": "android_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "¿Qué opina del producto Privacy Pro?",
+        "descriptionText": "Si completa nuestra breve encuesta, utilizaremos sus comentarios para mejorar Privacy Pro para todos los suscriptores.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Empezar encuesta",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=spanish_eu",
+          "additionalParameters": {
+            "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        23
+      ],
+      "exclusionRules": [
+        8
+      ]
+    },
+    {
+      "id": "android_privacy_pro_subscriber_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Vad tycker du om Privacy Pro?",
+        "descriptionText": "Om du fyller i vår korta enkät kommer vi att använda dina synpunkter för att förbättra Privacy Pro för alla prenumeranter.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Starta enkät",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_android_newsubscribersurvey?list=4&decLang=swedish",
+          "additionalParameters": {
+            "queryParams": "var;man;av;ddgv;mo;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp;ppro_status"
+          }
+        }
+      },
+      "matchingRules": [
+        24
+      ],
+      "exclusionRules": [
+        8
+      ]
+    },
+    {
       "id": "android_permanent_survey_user_satisfaction",
       "content": {
         "messageType": "big_single_action",
@@ -521,6 +682,216 @@
           "value": [
             "en-GB",
             "en-CA"
+          ]
+        }
+      }
+    },
+    {
+      "id": 18,
+      "attributes": {
+        "appVersion": {
+          "min": "5.206.1"
+        },
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "active"
+          ]
+        },
+        "locale": {
+          "value": [
+            "en-GB",
+            "en-CA"
+          ]
+        }
+      }
+    },
+    {
+      "id": 19,
+      "attributes": {
+        "appVersion": {
+          "min": "5.206.1"
+        },
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "active"
+          ]
+        },
+        "locale": {
+          "value": [
+            "fr-FR",
+            "fr-CA",
+            "fr-BE",
+            "fr-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 20,
+      "attributes": {
+        "appVersion": {
+          "min": "5.206.1"
+        },
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "active"
+          ]
+        },
+        "locale": {
+          "value": [
+            "de-DE",
+            "de-AT",
+            "de-CH"
+          ]
+        }
+      }
+    },
+    {
+      "id": 21,
+      "attributes": {
+        "appVersion": {
+          "min": "5.206.1"
+        },
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "active"
+          ]
+        },
+        "locale": {
+          "value": [
+            "nl-NL",
+            "nl-BE"
+          ]
+        }
+      }
+    },
+    {
+      "id": 22,
+      "attributes": {
+        "appVersion": {
+          "min": "5.206.1"
+        },
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "active"
+          ]
+        },
+        "locale": {
+          "value": [
+            "it-IT"
+          ]
+        }
+      }
+    },
+    {
+      "id": 23,
+      "attributes": {
+        "appVersion": {
+          "min": "5.206.1"
+        },
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "active"
+          ]
+        },
+        "locale": {
+          "value": [
+            "es-ES"
+          ]
+        }
+      }
+    },
+    {
+      "id": 24,
+      "attributes": {
+        "appVersion": {
+          "min": "5.206.1"
+        },
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproDaysSinceSubscribed": {
+          "min": 14
+        },
+        "pproPurchasePlatform": {
+          "value": [
+            "google"
+          ]
+        },
+        "pproSubscriptionStatus": {
+          "value": [
+            "active"
+          ]
+        },
+        "locale": {
+          "value": [
+            "sv-SE"
           ]
         }
       }


### PR DESCRIPTION
Tasks: 
- https://app.asana.com/0/1207619243206445/1209751758494085/f
- https://app.asana.com/0/1207619243206445/1209751758494080/f

This PR covers the Android survey translation for Privacy Pro. The new surveys reuse the same message IDs as the English messages, since we want to avoid showing an invitation to the same user multiple times, even if they change their device language.

The exact changes are:

**Android**:
* Added non-US English & subscriber exit survey
* Added French exit & subscriber surveys
* Added German exit & subscriber surveys
* Added Dutch exit & subscriber surveys
* Added Italian exit & subscriber surveys
* Added Spanish exit & subscriber surveys
* Added Swedish exit & subscriber surveys

**Testing steps:**
Overall this change is just adding localized versions of the existing surveys. The message ID is reused between messages so that users who see a message and then change language should not see it again.

To test this, first you need to get your device into either either subscriber or expiring states.

After that, simply test the languages being added by changing the app's scheme language setting and confirming that the messages show up. It's expected that if your device is showing one language and you then change it, you may not see the new language until RMF refreshes - this is considered acceptable.