### PR TITLE
Added tab control preview message

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 13,
+  "version": 14,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -92,6 +92,23 @@
       ],
       "exclusionRules": [
         9
+      ]
+    },
+    {
+      "id": "windows_tab_control_preview",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help us test the latest tab improvements!",
+        "descriptionText": "In the last update of DuckDuckGo Preview for Windows, we rebuilt tabs from the ground up to improve overall performance. Tabs should look and work the same, but we could use your help finding any issues we may have missed. If you encounter unexpected tab behavior, use the \"Send Browser Feedback\" menu option to tell us about it.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      },
+      "matchingRules": [
+        12
       ]
     }
   ],
@@ -233,6 +250,17 @@
           "value": [
             "survey.dismissed"
           ]
+        }
+      }
+    },
+    {
+      "id": 12,
+      "attributes": {
+        "appVersion": {
+          "min": "0.108.1"
+        },
+        "flavor": {
+          "value": [ "preview" ]
         }
       }
     }


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1207619243206445/task/1209936881597685?focus=true

This message adds a message to the preview build about upcoming tab control changes.

To test

- Install [0.108.2 preview](https://staticcdn.duckduckgo.com/d5c04536-5379-4709-8d19-d13fdd456ff6/preview/builds/0.108.2.0-a4ab232d/0.108.2.0/DuckDuckGo%20Preview_0.108.2.0.msixbundle)
- Become an internal user
- Change the 