### PR TITLE
Add iOS + macOS International Privacy Pro announcements (CA, GB)

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -375,6 +375,23 @@
       "exclusionRules": [
         1, 2, 17, 18, 20
       ]
+    },
+    {
+      "id": "funnel_newtab_ios_intlannouncement",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "NEW! Privacy Pro Subscription",
+        "descriptionText": "Enjoy peace of mind with a fast, secure VPN + Identity Theft Restoration.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Get Privacy Pro",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/pro?origin=funnel_newtab_ios_intlannouncement"
+        }
+      },
+      "matchingRules": [
+        21
+      ]
     }
   ],
   "rules": [
@@ -816,6 +833,29 @@
           "value": [
             "ddg_ios_survey_1"
           ]
+        }
+      }
+    },
+    {
+      "id": 21,
+      "attributes": {
+        "pproEligible": {
+          "value": true
+        },
+        "pproSubscriber": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "en-CA",
+            "en-GB"
+          ]
+        },
+        "daysSinceInstalled": {
+          "min": 7
+        },
+        "appVersion": {
+          "min": "7.131.0.1"
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 57,
+  "version": 58,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 18,
+  "version": 19,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -298,6 +298,23 @@
         "placeholder": "CriticalUpdate"
       },
       "matchingRules": [10]
+    },
+    {
+      "id": "funnel_newtab_macos_intlannouncement",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "NEW! Privacy Pro Subscription",
+        "descriptionText": "Enjoy peace of mind with a fast, secure VPN + Identity Theft Restoration.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Get Privacy Pro",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/pro?origin=funnel_newtab_macos_intlannouncement"
+        }
+      },
+      "matchingRules": [
+        23
+      ]
     }
   ],
   "rules": [
@@ -727,6 +744,29 @@
           "value": [
             "es-ES"
           ]
+        }
+      }
+    },
+    {
+      "id": 23,
+      "attributes": {
+        "pproEligible": {
+          "value": true
+        },
+        "pproSubscriber": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "en-CA",
+            "en-GB"
+          ]
+        },
+        "installedMacAppStore": {
+          "value": true
+        },
+        "appVersion": {
+          "min": "1.101.0"
         }
       }
     }


### PR DESCRIPTION
iOS: https://app.asana.com/1/137249556945/project/1207619243206445/task/1209945143669459
macOS: https://app.asana.com/1/137249556945/project/1207619243206445/task/1209945022865329

iOS Testing:
1. In the app debug menu, update the privacy config URL to: https://duckduckgo.github.io/privacy-configuration/pr-3004/v4/ios-config.json
2. Ensure your locale is `en-GB` or `en-CA`, and override properties in `RemoteMessagingConfigMatcherProvider` to match the message requirements (`isPrivacyProEligibleUser: true,  isPrivacyProSubscriber: false`)
3. In RemoteMessagingClient set the debug URL to staging ->  https://staticcdn.duckduckgo.com/remotemessaging/config/staging/pre/ios-config.json
4. Launch the app and validate message is shown and params are added to the remote message pixels

macOS Testing:
1. Ensure your locale is `en-GB` or `en-CA`, and override properties in `RemoteMessagingConfigMatcherProvider` to match the message requirements (`isInstalledMacAppStore: true, isPrivacyProEligibleUser: true, isPrivacyProSubscriber: false`)
2. In RemoteMessagingClient set the debug URL to staging ->  https://staticcdn.duckduckgo.com/remotemessaging/config/staging/macos-config.json
3. Launch the app and validate message is shown 
