### PR TITLE
Remove iOS quarterly survey (April 2025)

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 58,
+  "version": 59,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -351,29 +351,6 @@
       },
       "matchingRules": [
         4
-      ]
-    },
-    {
-      "id": "ios_quarterly_satisfaction_survey_q2_2025",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "Announce",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240903?list=6",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;locale"
-          }
-        }
-      },
-      "matchingRules": [
-        19
-      ],
-      "exclusionRules": [
-        1, 2, 17, 18, 20
       ]
     },
     {
@@ -802,25 +779,6 @@
       }
     },
 
-    {
-      "id": 19,
-      "targetPercentile": {
-        "before": 0.2
-      },
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
-          ]
-        },
-        "appVersion": {
-          "min": "7.123.0.0"
-        }
-      }
-    },
     {
       "id": 20,
       "attributes": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -780,21 +780,6 @@
     },
 
     {
-      "id": 20,
-      "attributes": {
-        "interactedWithMessage": {
-          "value": [
-            "ddg_ios_survey_1"
-          ]
-        },
-        "messageShown": {
-          "value": [
-            "ddg_ios_survey_1"
-          ]
-        }
-      }
-    },
-    {
       "id": 21,
       "attributes": {
         "pproEligible": {


### PR DESCRIPTION
This PR removes the survey added in https://github.com/duckduckgo/remote-messaging-config/pull/160.

To test this, check that the additions in the PR above were correctly removed.