### PR TITLE
Remove iOS + macOS International Privacy Pro announcements (CA, GB)

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 59,
+  "version": 60,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -351,23 +351,6 @@
       },
       "matchingRules": [
         4
-      ]
-    },
-    {
-      "id": "funnel_newtab_ios_intlannouncement",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "NEW! Privacy Pro Subscription",
-        "descriptionText": "Enjoy peace of mind with a fast, secure VPN + Identity Theft Restoration.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Get Privacy Pro",
-        "primaryAction": {
-          "type": "url",
-          "value": "https://duckduckgo.com/pro?origin=funnel_newtab_ios_intlannouncement"
-        }
-      },
-      "matchingRules": [
-        21
       ]
     }
   ],
@@ -775,30 +758,6 @@
         },
         "locale": {
           "value": ["en-CA", "en-GB"]
-        }
-      }
-    },
-
-    {
-      "id": 21,
-      "attributes": {
-        "pproEligible": {
-          "value": true
-        },
-        "pproSubscriber": {
-          "value": false
-        },
-        "locale": {
-          "value": [
-            "en-CA",
-            "en-GB"
-          ]
-        },
-        "daysSinceInstalled": {
-          "min": 7
-        },
-        "appVersion": {
-          "min": "7.131.0.1"
         }
       }
     }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 19,
+  "version": 20,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",
@@ -298,23 +298,6 @@
         "placeholder": "CriticalUpdate"
       },
       "matchingRules": [10]
-    },
-    {
-      "id": "funnel_newtab_macos_intlannouncement",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "NEW! Privacy Pro Subscription",
-        "descriptionText": "Enjoy peace of mind with a fast, secure VPN + Identity Theft Restoration.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Get Privacy Pro",
-        "primaryAction": {
-          "type": "url",
-          "value": "https://duckduckgo.com/pro?origin=funnel_newtab_macos_intlannouncement"
-        }
-      },
-      "matchingRules": [
-        23
-      ]
     }
   ],
   "rules": [
@@ -744,29 +727,6 @@
           "value": [
             "es-ES"
           ]
-        }
-      }
-    },
-    {
-      "id": 23,
-      "attributes": {
-        "pproEligible": {
-          "value": true
-        },
-        "pproSubscriber": {
-          "value": false
-        },
-        "locale": {
-          "value": [
-            "en-CA",
-            "en-GB"
-          ]
-        },
-        "installedMacAppStore": {
-          "value": true
-        },
-        "appVersion": {
-          "min": "1.101.0"
         }
       }
     }


### PR DESCRIPTION
iOS: https://app.asana.com/1/137249556945/project/1207619243206445/task/1209945143669459
macOS: https://app.asana.com/1/137249556945/project/1207619243206445/task/1209945022865329

Removes the iOS & macOS messages added as part of https://github.com/duckduckgo/remote-messaging-config/pull/164

Testing iOS:
- Confirm config version number has been incremented
- Confirm message with id `funnel_newtab_ios_intlannouncement` has been removed
- Confirm associated rule id `21` has been removed

Testing macOS:
- Confirm config version number has been incremented
- Confirm message with id `funnel_newtab_ios_intlannouncement` has been removed
- Confirm associated rule id `23` has been removed