### PR TITLE
Remove Android International Privacy Pro announcement (CA, GB)

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 48,
+  "version": 49,
   "messages": [
     {
       "id": "android_privacy_pro_exit_survey_1",
@@ -366,23 +366,6 @@
       ],
       "exclusionRules": [
         10
-      ]
-    },
-    {
-      "id": "funnel_newtab_android_intlannouncement",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "NEW! Privacy Pro Subscription",
-        "descriptionText": "Enjoy peace of mind with a fast, secure VPN + Identity Theft Restoration.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Get Privacy Pro",
-        "primaryAction": {
-          "type": "url",
-          "value": "https://duckduckgo.com/pro?origin=funnel_newtab_android_intlannouncement"
-        }
-      },
-      "matchingRules": [
-        25
       ]
     }
   ],
@@ -910,29 +893,6 @@
         "locale": {
           "value": [
             "sv-SE"
-          ]
-        }
-      }
-    },
-    {
-      "id": 25,
-      "attributes": {
-        "appVersion": {
-          "min": "5.210.0"
-        },
-        "daysSinceInstalled": {
-          "min": 7
-        },
-        "pproEligible": {
-          "value": true
-        },
-        "pproSubscriber": {
-          "value": false
-        },
-        "locale": {
-          "value": [
-            "en-GB",
-            "en-CA"
           ]
         }
       }


### PR DESCRIPTION
Asana: https://app.asana.com/1/137249556945/task/1209945768616164?focus=true

This PR removes the survey added in https://github.com/duckduckgo/remote-messaging-config/pull/163

To test, check that the survey is correctly removed based on the diff of the original PR linked above.