### PR TITLE
Add iOS International Privacy Pro translated announcements

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -861,7 +861,6 @@
             "pl-PL",
             "pt-PT",
             "ro-RO",
-            "ru-RU",
             "es-ES",
             "sv-SE",
             "en-IE"

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 60,
+  "version": 61,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -351,6 +351,86 @@
       },
       "matchingRules": [
         4
+      ]
+    },
+
+    {
+      "id": "funnel_newtab_ios_intlannouncement",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "NEW! Privacy Pro Subscription",
+        "descriptionText": "Enjoy peace of mind with a fast, secure VPN + Identity Theft Restoration.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Get Privacy Pro",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/pro?origin=funnel_newtab_ios_intlannouncement"
+        }
+      },
+      "translations": {
+        "cs-CZ": {
+          "titleText": "NOVINKA! Předplatné Privacy Pro",
+          "descriptionText": "Už žádné starosti díky rychlé a zabezpečené VPN a obnově identity.",
+          "primaryActionText": "Pořiď si službu Privacy Pro"
+        },
+        "nl-NL": {
+          "titleText": "NIEUW! Privacy Pro-abonnement",
+          "descriptionText": "Ervaar gemoedsrust met een snelle, veilige VPN + herstel bij identiteitsdiefstal.",
+          "primaryActionText": "Privacy Pro kopen"
+        },
+        "fr-FR": {
+          "titleText": "NOUVEAUTE! L'abonnement Privacy Pro",
+          "descriptionText": "Gardez l'esprit tranquille grâce à un VPN rapide et sécurisé ainsi qu'à une assistance pour restaurer votre identité en cas de vol.",
+          "primaryActionText": "Passez à Privacy Pro"
+        },
+        "de-DE": {
+          "titleText": "NEU! Privacy Pro Abonnement",
+          "descriptionText": "Erhalte zusätzlichen Schutz mit einem schnellen, sicheren VPN und der Wiederherstellung bei Identitätsdiebstahl.",
+          "primaryActionText": "Privacy Pro kaufen"
+        },
+        "hu-HU": {
+          "titleText": "ÚJDONSÁG! Privacy Pro-előfizetés",
+          "descriptionText": "Szerezz extra védelmet a gyors és biztonságos VPN és a személyazonosság-lopás utáni helyreállítás funkció segítségével.",
+          "primaryActionText": "Privacy Pro előfizetése"
+        },
+        "it-IT": {
+          "titleText": "NOVITÀ! Abbonamento a Privacy Pro",
+          "descriptionText": "Approfitta di una protezione extra con una VPN veloce e sicura + ripristino in caso di furto d'identità.",
+          "primaryActionText": "Attiva Privacy Pro"
+        },
+        "pl-PL": {
+          "titleText": "NOWOŚĆ! Subskrypcja Privacy Pro",
+          "descriptionText": "Ciesz się spokojem ducha dzięki szybkiej i bezpiecznej sieci VPN oraz funkcji usuwania skutków kradzieży tożsamości.",
+          "primaryActionText": "Uzyskaj Privacy Pro"
+        },
+        "pt-PT": {
+          "titleText": "NOVIDADE! Subscrição Privacy Pro",
+          "descriptionText": "Obtém proteção extra com uma VPN rápida e segura + recuperação de roubo de identidade.",
+          "primaryActionText": "Adere ao Privacy Pro"
+        },
+        "ro-RO": {
+          "titleText": "NOU! Abonament Privacy Pro",
+          "descriptionText": "Bucură-te de liniște sufletească cu un VPN rapid și sigur + restaurarea identității furate.",
+          "primaryActionText": "Obține Privacy Pro"
+        },
+        "es-ES": {
+          "titleText": "¡NOVEDAD! Suscripción a Privacy Pro",
+          "descriptionText": "Disfruta de la tranquilidad de una VPN rápida, segura con restauración de identidad.",
+          "primaryActionText": "Consigue Privacy Pro"
+        },
+        "sv-SE": {
+          "titleText": "NYTT! Privacy Pro-abonnemang",
+          "descriptionText": "Njut av sinnesro med ett snabbt, säkert VPN + Identity Theft Restoration.",
+          "primaryActionText": "Skaffa Privacy Pro"
+        },
+        "en-IE": {
+          "titleText": "NEW! Privacy Pro Subscription",
+          "descriptionText": "Enjoy peace of mind with a fast, secure VPN + Identity Theft Restoration.",
+          "primaryActionText": "Get Privacy Pro"
+        }
+      },
+      "matchingRules": [
+        21
       ]
     }
   ],
@@ -758,6 +838,40 @@
         },
         "locale": {
           "value": ["en-CA", "en-GB"]
+        }
+      }
+    },
+    {
+      "id": 21,
+      "attributes": {
+        "pproEligible": {
+          "value": true
+        },
+        "pproSubscriber": {
+          "value": false
+        },
+        "locale": {
+          "value": [
+            "cs-CZ",
+            "nl-NL",
+            "fr-FR",
+            "de-DE",
+            "hu-HU",
+            "it-IT",
+            "pl-PL",
+            "pt-PT",
+            "ro-RO",
+            "ru-RU",
+            "es-ES",
+            "sv-SE",
+            "en-IE"
+          ]
+        },
+        "daysSinceInstalled": {
+          "min": 7
+        },
+        "appVersion": {
+          "min": "7.131.0.1"
         }
       }
     }


### PR DESCRIPTION
Task: https://app.asana.com/1/137249556945/project/1207619243206445/task/1209734738279904

Test steps:
1. Using a simulator (or device) that has had the app installed for at least 7 days, sign out of privacy pro (if necessary) & set both the locale AND language to any of the locales listed under rule `21`
2. Override these properties in `RemoteMessagingConfigMatcherProvider` to match the message requirements:  `isPrivacyProEligibleUser: true,  isPrivacyProSubscriber: false`
3. In `RemoteMessagingClient` set the debug URL to this jsonblob url https://www.jsonblob.com/api/1359858463055994880 (it’s the exact ios-config.json file contents from this PR, just using as the staging url is being overwritten by another PR 🙂)
4. Launch the app and validate that the translated message is shown 
5. Confirm that the RMF pixels fired have a randomised set of parameters attached like so: 
![image](https://github.com/user-attachments/assets/e1f25472-d533-4f8a-812e-c90eecba6a79)

6. Tap through on the message, and confirm you are taken to the translated Privacy Pro sign up screen!
