### PR TITLE
windows duck player outage cta

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,6 +1,18 @@
 {
-  "version": 16,
+  "version": 17,
   "messages": [
+    {
+      "id": "windows_duck_player_outage_update_cta",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Update DuckDuckGo to fix Duck Player issue",
+        "descriptionText": "We have resolved an issue affecting YouTube and Duck Player. To ensure a smooth experience, please update to the latest version of the DuckDuckGo app.",
+        "placeholder": "DDGAnnounce"
+      },
+      "matchingRules": [
+        13
+      ]
+    },
     {
       "id": "windows_privacy_pro_exit_survey_1",
       "content": {
@@ -261,6 +273,15 @@
         },
         "flavor": {
           "value": [ "preview" ]
+        }
+      }
+    },
+    {
+      "id": 13,
+      "attributes": {
+        "appVersion": {
+          "min": "0.100.4.0",
+          "max": "0.109.6.0"
         }
       }
     }


### PR DESCRIPTION
this adds a cta to tell users to update to the latest version since duck player is broken on versions less than 0.109.7.0