### PR TITLE
Temporarily disable Windows VR RMF

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 24,
+  "version": 25,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -356,7 +356,7 @@
       "id": 13,
       "attributes": {
         "appVersion": {
-          "min": "0.116.5"
+          "min": "0.116.6"
         },
         "allFeatureFlagsEnabled": {
           "value": [


### PR DESCRIPTION
The RMF is still showing when it shouldn’t.

Disable it until we can figure out why.