### PR TITLE
Bump Windows VR minVersion again

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 27,
+  "version": 28,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -402,7 +402,7 @@
       "id": 13,
       "attributes": {
         "appVersion": {
-          "min": "0.118.0"
+          "min": "0.119.0"
         },
         "allFeatureFlagsEnabled": {
           "value": [


### PR DESCRIPTION
The corresponding product change didn’t make it into 118 so bumping the minVersion to 119.0 to ensure the RMF displays correctly.