### PR TITLE
Reduce Windows VR minVersion to 118

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 30,
+  "version": 31,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -356,7 +356,7 @@
       "id": 13,
       "attributes": {
         "appVersion": {
-          "min": "0.119.0"
+          "min": "0.118.0"
         },
         "allFeatureFlagsEnabled": {
           "value": [


### PR DESCRIPTION
Windows VR rollout is at 100%, so we can drop the minVersion requirement to 118 (current stable).