### PR TITLE
Add `last_search_state` to the macOS tab bar survey

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 26,
+  "version": 27,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -283,7 +283,7 @@
           "type": "survey",
           "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/241004?list=2",
           "additionalParameters": {
-            "queryParams": "delta;var;osv;ddgv"
+            "queryParams": "delta;var;osv;ddgv;last_search_state"
           }
         }
       },


### PR DESCRIPTION
Task: https://app.asana.com/1/137249556945/project/1207619243206445/task/1209078168689571?focus=true

This PR adds the `last_search_state` parameter to the survey that was added in https://github.com/duckduckgo/remote-messaging-config/pull/133.

**How to test:**
1. Set the browser up with the conditions to meet https://github.com/duckduckgo/remote-messaging-config/pull/133
2. Check that the new parameter is included in the survey URL