### PR TITLE
Remove macOS PPro free trial message

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -298,23 +298,6 @@
         "placeholder": "CriticalUpdate"
       },
       "matchingRules": [10]
-    },
-    {
-      "id": "funnel_newtab_macos_freetrialannouncement",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Try Privacy Pro free for 7 days",
-        "descriptionText": "Enjoy peace of mind with a fast, secure VPN + 2 other premium protections.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Get Privacy Pro",
-        "primaryAction": {
-          "type": "url",
-          "value": "https://duckduckgo.com/pro?origin=funnel_newtab_macos_freetrialannouncement"
-        }
-      },
-      "matchingRules": [
-        23
-      ]
     }
   ],
   "rules": [
@@ -744,26 +727,6 @@
           "value": [
             "es-ES"
           ]
-        }
-      }
-    },
-    {
-      "id": 23,
-      "attributes": {
-        "pproEligible": {
-          "value": true
-        },
-        "pproSubscriber": {
-          "value": false
-        },
-        "locale": {
-          "value": ["en-US"]
-        },
-        "daysSinceInstalled": {
-          "min": 7
-        },
-        "appVersion": {
-          "min": "1.144.0"
         }
       }
     }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 27,
+  "version": 28,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",


### PR DESCRIPTION
Task: https://app.asana.com/1/137249556945/task/1210892473051017?focus=true

Description: Removes macOS promo added as part of [PR 218](https://github.com/duckduckgo/remote-messaging-config/pull/218)

Test Steps:
- Confirm message with id `funnel_newtab_macos_freetrialannouncement` has been removed
- Confirm associated rule id `23` has been removed
- Confirm config id has been updated