### PR TITLE
Remove iOS PPro free trial message

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 70,
+  "version": 71,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -351,24 +351,6 @@
       },
       "matchingRules": [
         4
-      ]
-    },
-
-    {
-      "id": "funnel_newtab_ios_freetrialannouncement",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Try Privacy Pro free for 7 days",
-        "descriptionText": "Enjoy peace of mind with a fast, secure VPN and other premium protections",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Get Privacy Pro",
-        "primaryAction": {
-          "type": "url",
-          "value": "https://duckduckgo.com/pro?origin=funnel_newtab_ios_freetrialannouncement"
-        }
-      },
-      "matchingRules": [
-        19
       ]
     }
 
@@ -777,26 +759,6 @@
         },
         "locale": {
           "value": ["en-CA", "en-GB"]
-        }
-      }
-    },
-    {
-      "id": 19,
-      "attributes": {
-        "pproEligible": {
-          "value": true
-        },
-        "pproSubscriber": {
-          "value": false
-        },
-        "locale": {
-          "value": ["en-CA", "en-GB", "en-US"]
-        },
-        "daysSinceInstalled": {
-          "min": 7
-        },
-        "appVersion": {
-          "min": "7.171.0"
         }
       }
     }


### PR DESCRIPTION
Task: https://app.asana.com/1/137249556945/project/1207619243206445/task/1210890590852276?focus=true

Description: Removes iOS promo added as part of https://github.com/duckduckgo/remote-messaging-config/pull/218

Test Steps:
- Confirm message with id `funnel_newtab_ios_freetrialannouncement` has been removed
- Confirm associated rule id `19` has been removed
- Confirm config `id` has been updated