### PR TITLE
add config for duck ai announcement

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,6 +1,21 @@
 {
-  "version": 71,
+  "version": 72,
   "messages": [
+ {
+      "id": "search_duck_ai_announcement",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Toggle between search and AI chat",
+        "descriptionText": "Try our experimental address bar. Either way, your info stays private.",
+        "placeholder": "Announce",
+        "primaryActionText": "Enable in Settings",
+        "primaryAction": {
+          "type": "navigation",
+          "value": "duckai.settings"
+        }
+      },
+      "matchingRules": [19]
+    },
     {
       "id": "ios_privacy_pro_exit_survey_1",
       "content": {
@@ -759,6 +774,35 @@
         },
         "locale": {
           "value": ["en-CA", "en-GB"]
+        }
+      }
+    },
+    {
+      "id": 19,
+      "appVersion": {
+          "min": "7.184.0"
+      },
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-AU",
+            "en-BZ",
+            "en-CA",
+            "en-cb",
+            "en-GB",
+            "en-IE",
+            "en-IN",
+            "en-JM",
+            "en-MT",
+            "en-MY",
+            "en-NZ",
+            "en-PH",
+            "en-SG",
+            "en-TT",
+            "en-US",
+            "en-ZA",
+            "en-ZW"
+          ]
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -6,7 +6,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Toggle between search and AI chat",
-        "descriptionText": "Try our experimental address bar. Either way, your info stays private.",
+        "descriptionText": "Try our experimental address bar. All AI features are optional.",
         "placeholder": "Announce",
         "primaryActionText": "Enable in Settings",
         "primaryAction": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -799,17 +799,28 @@
         }
       }
     },
+    
     {
       "id": 19,
       "targetPercentile": {
         "before": 0.2
+      },
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        },
+        "appVersion": {
+          "min": "7.123.0.0"
+        }
       }
     },
     {
       "id": 20,
-      "appVersion": {
-          "min": "7.123.0.0"
-      },
       "attributes": {
         "interactedWithMessage": {
           "value": [

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -799,7 +799,7 @@
         }
       }
     },
-    
+
     {
       "id": 19,
       "targetPercentile": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -8,7 +8,7 @@
         "titleText": "Toggle between search and AI chat",
         "descriptionText": "Try our experimental address bar. All AI features are optional.",
         "placeholder": "Announce",
-        "primaryActionText": "Enable in Settings",
+        "primaryActionText": "Enable in AI Settings",
         "primaryAction": {
           "type": "navigation",
           "value": "duckai.settings"


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/392891325557410/task/1211152384110677?focus=true

To test:

* Check out the 7.184.0 release branch
* Update RemoteMessageClient to point at the link below
* Run the app 
* If you don't see the message go to Debug > Remote Message, tap "Delete", then "Reload". If the message appears at the top of that screen it should then be visible on the new tab page.

