### PR TITLE
[NO NOT MERGE TILL 4th SEP] Subscription rebrand/duck.ai paid messages

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,12 +1,77 @@
 {
-  "version": 36,
+  "version": 37,
   "messages": [
+    {
+      "id": "windows_duck_ai_paid_promo",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "New! Advanced AI for Subscribers",
+        "descriptionText": "Your subscription now includes access to more advanced AI models in Duck.ai, our private AI chat service. Always optional. No extra cost.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Try Duck.ai",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=3&origin=funnel_newtab_windows_advancedai_us"
+        }
+      },
+      "matchingRules": [
+        12
+      ]
+    },
+    {
+      "id": "windows_duck_ai_paid_new_terms",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "New! Advanced AI for Subscribers",
+        "descriptionText": "We've added advanced, private (optional) AI to your subscription at no extra cost. Terms of Service updated accordingly.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Try Duck.ai",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=3&origin=funnel_newtab_windows_advancedai_us"
+        },
+        "secondaryActionText": "View Terms",
+        "secondaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/pro/privacy-terms/non-us/en"
+        }
+      },
+      "translations": {
+        "fr-FR": {
+          "titleText": "Nouveau ! IA avancée pour les abonnés",
+          "descriptionText": "Nous avons intégré un chat IA avancé et privé en option à votre abonnement, sans frais supplémentaire. Les conditions d'utilisation ont été mises à jour.",
+          "primaryActionText": "Essayer Duck.ai",
+          "secondaryActionText": "Voir les conditions"
+        },
+        "de-DE": {
+          "titleText": "Neu! Bessere KI für Abonnenten",
+          "descriptionText": "Wir haben deinem Abonnement einen besseren, privaten (optionalen) KI-Chat ohne zusätzliche Kosten hinzugefügt. Die Nutzungsbedingungen wurden entsprechend aktualisiert.",
+          "primaryActionText": "Probiere Duck.ai aus",
+          "secondaryActionText": "Nutzungsbedingungen anzeigen"
+        },
+        "nl-NL": {
+          "titleText": "Nieuw! Geavanceerde AI voor abonnees",
+          "descriptionText": "We hebben geavanceerde, privé (optionele) AI-chat aan je abonnement toegevoegd zonder extra kosten. De algemene voorwaarden zijn overeenkomstig bijgewerkt.",
+          "primaryActionText": "Probeer Duck.ai",
+          "secondaryActionText": "Bekijk voorwaarden"
+        },
+        "es-ES": {
+          "titleText": "¡Nuevo! IA avanzada para suscriptores",
+          "descriptionText": "Hemos añadido chat de IA avanzada, privada y opcional a tu suscripción sin coste adicional. Condiciones de servicio actualizadas en consecuencia.",
+          "primaryActionText": "Prueba Duck.ai",
+          "secondaryActionText": "Ver términos"
+        }
+      },
+      "matchingRules": [
+        13
+      ]
+    },
     {
       "id": "windows_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Tell Us Why You Left Privacy Pro",
-        "descriptionText": "By taking our brief survey, you'll help improve Privacy Pro for all subscribers.",
+        "titleText": "Why did you cancel your subscription?",
+        "descriptionText": "Your input helps improve DuckDuckGo for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
@@ -29,8 +94,8 @@
       "id": "windows_privacy_pro_subscriber_survey_1",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Tell Us Your Thoughts on Privacy Pro",
-        "descriptionText": "By completing our brief survey, you will help improve the Privacy Pro experience for all subscribers.",
+        "titleText": "What do you think of your subscription?",
+        "descriptionText": "Your input helps improve DuckDuckGo for all subscribers.",
         "placeholder": "PrivacyShield",
         "primaryActionText": "Take Survey",
         "primaryAction": {
@@ -210,6 +275,40 @@
           "value": [
             "survey.dismissed"
           ]
+        }
+      }
+    },
+    {
+      "id": 12,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproSubscriptionStatus": {
+          "value": "active"
+        },
+        "appVersion": {
+          "min": "0.126.2"
+        },
+        "locale": {
+          "value": [ "en-US", "en-CA" ]
+        }
+      }
+    },
+    {
+      "id": 13,
+      "attributes": {
+        "pproSubscriber": {
+          "value": true
+        },
+        "pproSubscriptionStatus": {
+          "value": "active"
+        },
+        "appVersion": {
+          "min": "0.126.2"
+        },
+        "locale": {
+          "value": [ "en-GB", "es-ES", "en-ES", "fr-FR", "en-FR", "de-DE", "en-DE", "nl-NL", "en-NL", "bg-BG", "en-BG", "cs-CZ", "en-CZ", "da-DK", "en-DK", "el-GR", "en-GR", "et-EE", "en-EE", "fi-FI", "sv-FI", "en-FI", "hr-HR", "en-HR", "hu-HU", "en-HU", "it-IT", "en-IT", "lt-LT", "en-LT", "lv-LV", "en-LV", "pl-PL", "en-PL", "pt-PT", "en-PT", "ro-RO", "en-RO", "sk-SK", "en-SK", "sl-SI", "en-SI", "sv-SE", "en-SE", "en-IE", "mt-MT", "en-MT", "el-CY", "tr-CY", "en-CY", "lb-LU", "fr-LU", "de-LU", "en-LU", "de-AT", "en-AT", "nl-BE", "fr-BE", "de-BE", "en-BE" ]
         }
       }
     }


### PR DESCRIPTION
This PR adds two new remote messages, and updates the copy on two others.

### Privacy Pro -> Subscription rebrand

Since we're rebranding privacy pro -> DuckDuckGo subscription the entry and exit surveys need new copy. See - https://app.asana.com/1/137249556945/project/1142021229838617/task/1211139551007095?focus=true


### Duck.ai paid announcements

There are two announcements for duck.ai paid that are going out for the release on 4th Sep. See below tasks for more details
https://app.asana.com/1/137249556945/project/1207619243206445/task/1210705710741042?focus=true
https://app.asana.com/1/137249556945/project/1207619243206445/task/1210694902630008?focus=true