### PR TITLE
Remove August 2025 iOS survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 73,
+  "version": 74,
   "messages": [
  {
       "id": "search_duck_ai_announcement",
@@ -366,29 +366,6 @@
       },
       "matchingRules": [
         4
-      ]
-    },
-    {
-      "id": "ios_quarterly_satisfaction_survey_q3_2025",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "Announce",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240903?list=8",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;locale;last_search_state"
-          }
-        }
-      },
-      "matchingRules": [
-        19
-      ],
-      "exclusionRules": [
-        1, 2, 17, 18, 20
       ]
     }
   ],
@@ -800,41 +777,6 @@
       }
     },
 
-    {
-      "id": 19,
-      "targetPercentile": {
-        "before": 0.2
-      },
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
-          ]
-        },
-        "appVersion": {
-          "min": "7.123.0.0"
-        }
-      }
-    },
-    {
-      "id": 20,
-      "attributes": {
-        "interactedWithMessage": {
-          "value": [
-            "ddg_ios_survey_1",
-            "ios_quarterly_satisfaction_survey_q2_2025"
-          ]
-        },
-        "messageShown": {
-          "value": [
-            "ddg_ios_survey_1"
-          ]
-        }
-      }
-    },
     {
       "id": 21,
       "appVersion": {


### PR DESCRIPTION
**Task:** https://app.asana.com/1/137249556945/task/1211121506202942?focus=true

This PR removes the survey added in https://github.com/duckduckgo/remote-messaging-config/pull/234.

**How to test:**
1. Check that the removed survey values match those that were added in the [original PR](https://github.com/duckduckgo/remote-messaging-config/pull/234)
2. Check that no other surveys refer to the removed rules