### PR TITLE
Remove Search + Duck.ai announcement (Android)

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,23 +1,6 @@
 {
-  "version": 66,
+  "version": 67,
   "messages": [
-    {
-      "id": "search_duck_ai_announcement",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Toggle between search and AI chat",
-        "descriptionText": "Try our experimental address bar. All AI features are optional.",
-        "placeholder": "Announce",
-        "primaryActionText": "Enable in AI Settings",
-        "primaryAction": {
-          "type": "navigation",
-          "value": "duckai.settings"
-        }
-      },
-      "matchingRules": [
-        28
-      ]
-    },
     {
       "id": "android_day5_experiment_survey",
       "content": {
@@ -904,35 +887,6 @@
             "en-CA",
             "en-GB",
             "en-AU"
-          ]
-        }
-      }
-    },
-    {
-      "id": 28,
-      "attributes": {
-        "appVersion": {
-          "min": "5.246.0"
-        },
-        "locale": {
-          "value": [
-            "en-AU",
-            "en-BZ",
-            "en-CA",
-            "en-cb",
-            "en-GB",
-            "en-IE",
-            "en-IN",
-            "en-JM",
-            "en-MT",
-            "en-MY",
-            "en-NZ",
-            "en-PH",
-            "en-SG",
-            "en-TT",
-            "en-US",
-            "en-ZA",
-            "en-ZW"
           ]
         }
       }


### PR DESCRIPTION
Asana: https://app.asana.com/1/137249556945/task/1211163534187592?focus=true

Description: Removes the Search + Duck.ai announcement

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211163534187592