### PR TITLE
fixed the T&C link for duck.ai paid on all platforms

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 67,
+  "version": 68,
   "messages": [
     {
       "id": "android_ppro_duck_ai_launch_us",
@@ -33,7 +33,7 @@
         "secondaryActionText": "View Terms",
         "secondaryAction": {
           "type": "url",
-          "value": "https://duckduckgo.com/pro/privacy-terms/non-us/en"
+          "value": "https://duckduckgo.com/pro/privacy-terms/non-us"
         }
       },
       "translations": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 75,
+  "version": 76,
   "messages": [
       {
         "id": "ios_ppro_duck_ai_launch_us",
@@ -33,7 +33,7 @@
           "secondaryActionText": "View Terms",
           "secondaryAction": {
             "type": "url",
-            "value": "https://duckduckgo.com/pro/privacy-terms/non-us/en"
+            "value": "https://duckduckgo.com/pro/privacy-terms/non-us"
           }
         },
         "translations": {

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 29,
+  "version": 30,
   "messages": [
       {
         "id": "macos_ppro_duck_ai_launch_us",
@@ -31,7 +31,7 @@
           "secondaryActionText": "View Terms",
           "secondaryAction": {
             "type": "url",
-            "value": "https://duckduckgo.com/pro/privacy-terms/non-us/en"
+            "value": "https://duckduckgo.com/pro/privacy-terms/non-us"
           }
         },
         "translations": {

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 37,
+  "version": 38,
   "messages": [
     {
       "id": "windows_duck_ai_paid_promo",
@@ -33,7 +33,7 @@
         "secondaryActionText": "View Terms",
         "secondaryAction": {
           "type": "url",
-          "value": "https://duckduckgo.com/pro/privacy-terms/non-us/en"
+          "value": "https://duckduckgo.com/pro/privacy-terms/non-us"
         }
       },
       "translations": {


### PR DESCRIPTION
https://app.asana.com/1/137249556945/task/1211245588899245

Changed the T&C link from https://duckduckgo.com/pro/privacy-terms/non-us/en to https://duckduckgo.com/pro/privacy-terms/non-us to allow for locale to be picked up automatically.