### PR TITLE
Add update app RMF message for macOS users on 1.182.0 or earlier

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -303,7 +303,7 @@
       "id": "macos_update_app",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "DuckDuckGo app is out of date",
+        "titleText": "Your DuckDuckGo app is out of date",
         "descriptionText": "You're running an old version of DuckDuckGo that is missing important fixes and improvements. Download the latest version to stay up to date.",
         "placeholder": "AppUpdate",
         "primaryActionText": "Download Latest",

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -303,8 +303,8 @@
       "id": "macos_update_app",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Your DuckDuckGo app is out of date",
-        "descriptionText": "You're running an old version of DuckDuckGo that is missing important fixes and improvements.\n\nDownload the latest version to stay up to date.",
+        "titleText": "DuckDuckGo app is out of date",
+        "descriptionText": "You're running an old version of DuckDuckGo that is missing important fixes and improvements. Download the latest version to stay up to date.",
         "placeholder": "AppUpdate",
         "primaryActionText": "Download Latest",
         "primaryAction": {

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -306,7 +306,7 @@
         "titleText": "Your DuckDuckGo app is out of date",
         "descriptionText": "This version is missing important fixes and improvements. Download the latest version to stay up to date.",
         "placeholder": "AppUpdate",
-        "primaryActionText": "Download Latest",
+        "primaryActionText": "Go to App Store",
         "primaryAction": {
           "type": "url",
           "value": "https://duckduckgo.com/mac"
@@ -321,7 +321,7 @@
         "titleText": "Your DuckDuckGo app is out of date",
         "descriptionText": "This version is missing important fixes and improvements. Update now to get the latest — this update will also enable automatic updates going forward.",
         "placeholder": "AppUpdate",
-        "primaryActionText": "Download Latest",
+        "primaryActionText": "Update Now",
         "primaryAction": {
           "type": "url",
           "value": "https://duckduckgo.com/mac"

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -747,11 +747,7 @@
     },
     {
       "id": 23,
-      "attributes": {
-        "appVersion": {
-          "max": "1.173.0"
-        }
-      }
+      "attributes": {}
     }
   ]
 }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -300,7 +300,7 @@
       "matchingRules": [10]
     },
     {
-      "id": "macos_update_app",
+      "id": "macos_update_app_appstore",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Your DuckDuckGo app is out of date",
@@ -313,6 +313,21 @@
         }
       },
       "matchingRules": [23]
+    },
+    {
+      "id": "macos_update_app_sparkle",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Your DuckDuckGo app is out of date",
+        "descriptionText": "This version is missing important fixes and improvements. Update now to get the latest — this update will also enable automatic updates going forward.",
+        "placeholder": "AppUpdate",
+        "primaryActionText": "Download Latest",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/mac"
+        }
+      },
+      "matchingRules": [24]
     }
   ],
   "rules": [
@@ -747,7 +762,19 @@
     },
     {
       "id": 23,
-      "attributes": {}
+      "attributes": {
+        "installedMacAppStore": {
+          "value": true
+        }
+      }
+    },
+    {
+      "id": 24,
+      "attributes": {
+        "installedMacAppStore": {
+          "value": false
+        }
+      }
     }
   ]
 }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 46,
+  "version": 47,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",
@@ -298,6 +298,21 @@
         "placeholder": "CriticalUpdate"
       },
       "matchingRules": [10]
+    },
+    {
+      "id": "macos_update_app",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Your DuckDuckGo app is out of date",
+        "descriptionText": "You're running an old version of DuckDuckGo that may be missing important fixes and improvements. Download the latest version to stay up to date.",
+        "placeholder": "AppUpdate",
+        "primaryActionText": "Download Latest",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/mac"
+        }
+      },
+      "matchingRules": [23]
     }
   ],
   "rules": [
@@ -727,6 +742,14 @@
           "value": [
             "es-ES"
           ]
+        }
+      }
+    },
+    {
+      "id": 23,
+      "attributes": {
+        "appVersion": {
+          "max": "1.173.0"
         }
       }
     }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -304,7 +304,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Your DuckDuckGo app is out of date",
-        "descriptionText": "You're running an old version of DuckDuckGo that may be missing important fixes and improvements. Download the latest version to stay up to date.",
+        "descriptionText": "You're running an old version of DuckDuckGo that is missing important fixes and improvements.\n\nDownload the latest version to stay up to date.",
         "placeholder": "AppUpdate",
         "primaryActionText": "Download Latest",
         "primaryAction": {

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -304,7 +304,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Your DuckDuckGo app is out of date",
-        "descriptionText": "You're running an old version of DuckDuckGo that is missing important fixes and improvements. Download the latest version to stay up to date.",
+        "descriptionText": "This version is missing important fixes and improvements. Download the latest version to stay up to date.",
         "placeholder": "AppUpdate",
         "primaryActionText": "Download Latest",
         "primaryAction": {

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -480,7 +480,7 @@
           "primaryActionText": "Przejdź do App Store"
         },
         "ru": {
-          "titleText": "Доступно обновление приложения DuckDuckGo",
+          "titleText": "Ваше приложение DuckDuckGo устарело",
           "descriptionText": "Загрузите последнюю версию, чтобы получить важные исправления и улучшения и оставаться на актуальной версии.",
           "primaryActionText": "Перейти в App Store"
         },
@@ -537,7 +537,7 @@
           "primaryActionText": "Zaktualizuj teraz"
         },
         "ru": {
-          "titleText": "Доступно обновление приложения DuckDuckGo",
+          "titleText": "Ваше приложение DuckDuckGo устарело",
           "descriptionText": "Обновите сейчас, чтобы получить важные исправления и улучшения. Это также включит автоматические обновления в дальнейшем.",
           "primaryActionText": "Обновить сейчас"
         },

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -425,7 +425,7 @@
         "primaryActionText": "Go to App Store",
         "primaryAction": {
           "type": "url",
-          "value": "https://duckduckgo.com/mac"
+          "value": "https://apps.apple.com/app/duckduckgo-privacy-browser/id663592361"
         }
       },
       "matchingRules": [25]

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -955,6 +955,9 @@
     {
       "id": 27,
       "attributes": {
+        "appVersion": {
+          "max": "1.182.0"
+        },
         "installedMacAppStore": {
           "value": true
         }
@@ -963,6 +966,9 @@
     {
       "id": 28,
       "attributes": {
+        "appVersion": {
+          "max": "1.182.0"
+        },
         "installedMacAppStore": {
           "value": false
         }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -425,7 +425,7 @@
         "primaryActionText": "Go to App Store",
         "primaryAction": {
           "type": "url",
-          "value": "https://apps.apple.com/app/duckduckgo-privacy-browser/id663592361"
+          "value": "https://apps.apple.com/us/app/duckduckgo-duck-ai-vpn/id663592361"
         }
       },
       "matchingRules": [25]

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -415,6 +415,7 @@
       },
       "matchingRules": [10]
     },
+
     {
       "id": "macos_quarterly_satisfaction_survey_q2_2026",
       "content": {
@@ -917,6 +918,7 @@
         }
       }
     },
+
     {
       "id": 25,
       "targetPercentile": {

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -448,6 +448,48 @@
           "value": "https://apps.apple.com/us/app/duckduckgo-duck-ai-vpn/id663592361"
         }
       },
+      "translations": {
+        "fr": {
+          "titleText": "Votre application DuckDuckGo n'est pas à jour",
+          "descriptionText": "Téléchargez la dernière version pour obtenir d'importantes corrections et améliorations, et pour rester à jour.",
+          "primaryActionText": "Aller à l'App Store"
+        },
+        "de": {
+          "titleText": "Ihre DuckDuckGo-App ist veraltet",
+          "descriptionText": "Laden Sie die neueste Version herunter, um wichtige Korrekturen und Verbesserungen zu erhalten und auf dem neuesten Stand zu bleiben.",
+          "primaryActionText": "Zum App Store"
+        },
+        "nl": {
+          "titleText": "Uw DuckDuckGo-app is verouderd",
+          "descriptionText": "Download de nieuwste versie voor belangrijke oplossingen en verbeteringen, en om up-to-date te blijven.",
+          "primaryActionText": "Naar de App Store"
+        },
+        "it": {
+          "titleText": "La tua app DuckDuckGo non è aggiornata",
+          "descriptionText": "Scarica la versione più recente per importanti correzioni e miglioramenti e per rimanere aggiornato.",
+          "primaryActionText": "Vai all'App Store"
+        },
+        "es": {
+          "titleText": "Tu aplicación DuckDuckGo está desactualizada",
+          "descriptionText": "Descarga la última versión para obtener importantes correcciones y mejoras, y mantenerte al día.",
+          "primaryActionText": "Ir al App Store"
+        },
+        "pl": {
+          "titleText": "Twoja aplikacja DuckDuckGo jest nieaktualna",
+          "descriptionText": "Pobierz najnowszą wersję, aby uzyskać ważne poprawki i ulepszenia oraz być na bieżąco.",
+          "primaryActionText": "Przejdź do App Store"
+        },
+        "ru": {
+          "titleText": "Ваше приложение DuckDuckGo устарело",
+          "descriptionText": "Загрузите последнюю версию, чтобы получить важные исправления и улучшения и оставаться в курсе обновлений.",
+          "primaryActionText": "Перейти в App Store"
+        },
+        "pt": {
+          "titleText": "A tua aplicação DuckDuckGo está desatualizada",
+          "descriptionText": "Transfere a versão mais recente para obter correções e melhorias importantes e ficar atualizado.",
+          "primaryActionText": "Ir para a App Store"
+        }
+      },
       "matchingRules": [27]
     },
     {
@@ -461,6 +503,48 @@
         "primaryAction": {
           "type": "url",
           "value": "duck://settings/about"
+        }
+      },
+      "translations": {
+        "fr": {
+          "titleText": "Votre application DuckDuckGo n'est pas à jour",
+          "descriptionText": "Mettez à jour maintenant pour obtenir d'importantes corrections et améliorations. Cela activera également les mises à jour automatiques à l'avenir.",
+          "primaryActionText": "Mettre à jour maintenant"
+        },
+        "de": {
+          "titleText": "Ihre DuckDuckGo-App ist veraltet",
+          "descriptionText": "Aktualisieren Sie jetzt, um wichtige Korrekturen und Verbesserungen zu erhalten. Dadurch werden zukünftig auch automatische Updates aktiviert.",
+          "primaryActionText": "Jetzt aktualisieren"
+        },
+        "nl": {
+          "titleText": "Uw DuckDuckGo-app is verouderd",
+          "descriptionText": "Werk nu bij voor belangrijke oplossingen en verbeteringen. Hiermee worden voortaan ook automatische updates ingeschakeld.",
+          "primaryActionText": "Nu bijwerken"
+        },
+        "it": {
+          "titleText": "La tua app DuckDuckGo non è aggiornata",
+          "descriptionText": "Aggiorna ora per ottenere importanti correzioni e miglioramenti. In questo modo attiverai anche gli aggiornamenti automatici in futuro.",
+          "primaryActionText": "Aggiorna ora"
+        },
+        "es": {
+          "titleText": "Tu aplicación DuckDuckGo está desactualizada",
+          "descriptionText": "Actualiza ahora para obtener importantes correcciones y mejoras. Esto también activará las actualizaciones automáticas en adelante.",
+          "primaryActionText": "Actualizar ahora"
+        },
+        "pl": {
+          "titleText": "Twoja aplikacja DuckDuckGo jest nieaktualna",
+          "descriptionText": "Zaktualizuj teraz, aby uzyskać ważne poprawki i ulepszenia. Spowoduje to również włączenie automatycznych aktualizacji w przyszłości.",
+          "primaryActionText": "Zaktualizuj teraz"
+        },
+        "ru": {
+          "titleText": "Ваше приложение DuckDuckGo устарело",
+          "descriptionText": "Обновите сейчас, чтобы получить важные исправления и улучшения. Это также включит автоматические обновления в будущем.",
+          "primaryActionText": "Обновить сейчас"
+        },
+        "pt": {
+          "titleText": "A tua aplicação DuckDuckGo está desatualizada",
+          "descriptionText": "Atualiza agora para obter correções e melhorias importantes. Isto também ativará as atualizações automáticas no futuro.",
+          "primaryActionText": "Atualizar agora"
         }
       },
       "matchingRules": [28]

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -451,42 +451,42 @@
       "translations": {
         "fr": {
           "titleText": "Votre application DuckDuckGo n'est pas à jour",
-          "descriptionText": "Téléchargez la dernière version pour obtenir d'importantes corrections et améliorations, et pour rester à jour.",
-          "primaryActionText": "Aller à l'App Store"
+          "descriptionText": "Téléchargez la dernière version pour bénéficier de correctifs et d'améliorations importantes, et rester à jour.",
+          "primaryActionText": "Ouvrir l'App Store"
         },
         "de": {
           "titleText": "Ihre DuckDuckGo-App ist veraltet",
-          "descriptionText": "Laden Sie die neueste Version herunter, um wichtige Korrekturen und Verbesserungen zu erhalten und auf dem neuesten Stand zu bleiben.",
+          "descriptionText": "Laden Sie die neueste Version herunter, um wichtige Fehlerbehebungen und Verbesserungen zu erhalten und auf dem neuesten Stand zu bleiben.",
           "primaryActionText": "Zum App Store"
         },
         "nl": {
           "titleText": "Uw DuckDuckGo-app is verouderd",
-          "descriptionText": "Download de nieuwste versie voor belangrijke oplossingen en verbeteringen, en om up-to-date te blijven.",
+          "descriptionText": "Download de nieuwste versie voor belangrijke fixes en verbeteringen, en om up-to-date te blijven.",
           "primaryActionText": "Naar de App Store"
         },
         "it": {
-          "titleText": "La tua app DuckDuckGo non è aggiornata",
-          "descriptionText": "Scarica la versione più recente per importanti correzioni e miglioramenti e per rimanere aggiornato.",
+          "titleText": "L'app DuckDuckGo non è aggiornata",
+          "descriptionText": "Scarica la versione più recente per ricevere correzioni e miglioramenti importanti e restare aggiornato.",
           "primaryActionText": "Vai all'App Store"
         },
         "es": {
-          "titleText": "Tu aplicación DuckDuckGo está desactualizada",
-          "descriptionText": "Descarga la última versión para obtener importantes correcciones y mejoras, y mantenerte al día.",
-          "primaryActionText": "Ir al App Store"
+          "titleText": "Tu app DuckDuckGo está desactualizada",
+          "descriptionText": "Descarga la última versión para obtener correcciones y mejoras importantes y mantenerte al día.",
+          "primaryActionText": "Ir a la App Store"
         },
         "pl": {
           "titleText": "Twoja aplikacja DuckDuckGo jest nieaktualna",
-          "descriptionText": "Pobierz najnowszą wersję, aby uzyskać ważne poprawki i ulepszenia oraz być na bieżąco.",
+          "descriptionText": "Pobierz najnowszą wersję, aby otrzymać ważne poprawki i ulepszenia oraz zachować aktualność.",
           "primaryActionText": "Przejdź do App Store"
         },
         "ru": {
-          "titleText": "Ваше приложение DuckDuckGo устарело",
-          "descriptionText": "Загрузите последнюю версию, чтобы получить важные исправления и улучшения и оставаться в курсе обновлений.",
+          "titleText": "Доступно обновление приложения DuckDuckGo",
+          "descriptionText": "Загрузите последнюю версию, чтобы получить важные исправления и улучшения и оставаться на актуальной версии.",
           "primaryActionText": "Перейти в App Store"
         },
         "pt": {
           "titleText": "A tua aplicação DuckDuckGo está desatualizada",
-          "descriptionText": "Transfere a versão mais recente para obter correções e melhorias importantes e ficar atualizado.",
+          "descriptionText": "Transfere a versão mais recente para obteres correções e melhorias importantes e ficares atualizado.",
           "primaryActionText": "Ir para a App Store"
         }
       },
@@ -508,42 +508,42 @@
       "translations": {
         "fr": {
           "titleText": "Votre application DuckDuckGo n'est pas à jour",
-          "descriptionText": "Mettez à jour maintenant pour obtenir d'importantes corrections et améliorations. Cela activera également les mises à jour automatiques à l'avenir.",
+          "descriptionText": "Mettez à jour maintenant pour bénéficier de correctifs et d'améliorations importantes. Les mises à jour automatiques seront également activées par la suite.",
           "primaryActionText": "Mettre à jour maintenant"
         },
         "de": {
           "titleText": "Ihre DuckDuckGo-App ist veraltet",
-          "descriptionText": "Aktualisieren Sie jetzt, um wichtige Korrekturen und Verbesserungen zu erhalten. Dadurch werden zukünftig auch automatische Updates aktiviert.",
+          "descriptionText": "Aktualisieren Sie jetzt, um wichtige Fehlerbehebungen und Verbesserungen zu erhalten. Dadurch werden künftig auch automatische Updates aktiviert.",
           "primaryActionText": "Jetzt aktualisieren"
         },
         "nl": {
           "titleText": "Uw DuckDuckGo-app is verouderd",
-          "descriptionText": "Werk nu bij voor belangrijke oplossingen en verbeteringen. Hiermee worden voortaan ook automatische updates ingeschakeld.",
+          "descriptionText": "Werk nu bij voor belangrijke fixes en verbeteringen. Hierdoor worden voortaan ook automatische updates ingeschakeld.",
           "primaryActionText": "Nu bijwerken"
         },
         "it": {
-          "titleText": "La tua app DuckDuckGo non è aggiornata",
-          "descriptionText": "Aggiorna ora per ottenere importanti correzioni e miglioramenti. In questo modo attiverai anche gli aggiornamenti automatici in futuro.",
+          "titleText": "L'app DuckDuckGo non è aggiornata",
+          "descriptionText": "Aggiorna ora per ottenere correzioni e miglioramenti importanti. Così facendo verranno attivati anche gli aggiornamenti automatici.",
           "primaryActionText": "Aggiorna ora"
         },
         "es": {
-          "titleText": "Tu aplicación DuckDuckGo está desactualizada",
-          "descriptionText": "Actualiza ahora para obtener importantes correcciones y mejoras. Esto también activará las actualizaciones automáticas en adelante.",
+          "titleText": "Tu app DuckDuckGo está desactualizada",
+          "descriptionText": "Actualiza ahora para obtener correcciones y mejoras importantes. Esto también activará las actualizaciones automáticas a partir de ahora.",
           "primaryActionText": "Actualizar ahora"
         },
         "pl": {
           "titleText": "Twoja aplikacja DuckDuckGo jest nieaktualna",
-          "descriptionText": "Zaktualizuj teraz, aby uzyskać ważne poprawki i ulepszenia. Spowoduje to również włączenie automatycznych aktualizacji w przyszłości.",
+          "descriptionText": "Zaktualizuj teraz, aby otrzymać ważne poprawki i ulepszenia. Włączy to również automatyczne aktualizacje w przyszłości.",
           "primaryActionText": "Zaktualizuj teraz"
         },
         "ru": {
-          "titleText": "Ваше приложение DuckDuckGo устарело",
-          "descriptionText": "Обновите сейчас, чтобы получить важные исправления и улучшения. Это также включит автоматические обновления в будущем.",
+          "titleText": "Доступно обновление приложения DuckDuckGo",
+          "descriptionText": "Обновите сейчас, чтобы получить важные исправления и улучшения. Это также включит автоматические обновления в дальнейшем.",
           "primaryActionText": "Обновить сейчас"
         },
         "pt": {
           "titleText": "A tua aplicação DuckDuckGo está desatualizada",
-          "descriptionText": "Atualiza agora para obter correções e melhorias importantes. Isto também ativará as atualizações automáticas no futuro.",
+          "descriptionText": "Atualiza agora para obteres correções e melhorias importantes. Isto também ativará as atualizações automáticas a partir de agora.",
           "primaryActionText": "Atualizar agora"
         }
       },

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -440,7 +440,7 @@
         "primaryActionText": "Update Now",
         "primaryAction": {
           "type": "url",
-          "value": "https://duckduckgo.com/mac"
+          "value": "duck://settings/about"
         }
       },
       "matchingRules": [26]

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -420,7 +420,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Your DuckDuckGo app is out of date",
-        "descriptionText": "This version is missing important fixes and improvements. Download the latest version to stay up to date.",
+        "descriptionText": "Download the latest version for important fixes and improvements, and to stay up to date.",
         "placeholder": "AppUpdate",
         "primaryActionText": "Go to App Store",
         "primaryAction": {
@@ -435,7 +435,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Your DuckDuckGo app is out of date",
-        "descriptionText": "This version is missing important fixes and improvements. Update now to get the latest — this update will also enable automatic updates going forward.",
+        "descriptionText": "Update now to get important fixes and improvements. This will also turn on automatic updates going forward.",
         "placeholder": "AppUpdate",
         "primaryActionText": "Update Now",
         "primaryAction": {


### PR DESCRIPTION
Asana Task: https://app.asana.com/1/137249556945/task/1213532614867875?focus=true

Adds messaging to inform users that they should update to the latest version.

We won't send these messages out until https://github.com/duckduckgo/apple-browsers/pull/3903 is released and available to 100% of users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds two new remote messages gated to `appVersion <= 1.182.0`; primary risk is incorrect targeting/threshold causing unintended message display.
> 
> **Overview**
> Bumps `macos-config.json` version to `52` and adds two new remote messages that prompt macOS users on `1.182.0` or earlier to update the app.
> 
> Messaging is split by install channel: App Store installs get a CTA to open the App Store listing, while non–App Store installs get a CTA that deep-links to `duck://settings/about` to update (with localized strings for supported languages). New matching rules (`27`, `28`) target `appVersion` and `installedMacAppStore` to select the appropriate message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01502e7e5847bd63461e715bdb9a926245cf7831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->