### PR TITLE
Update net attribute rating survey target to 10%

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 98,
+  "version": 99,
   "messages": [
     {
       "id": "android_deprecation_early_notice_os8",
@@ -441,7 +441,7 @@
     {
       "id": 2,
       "targetPercentile": {
-        "before": 0.3
+        "before": 0.1
       },
       "attributes": {
         "locale": {


### PR DESCRIPTION
**Asana**: https://app.asana.com/1/137249556945/task/1213958714061239?focus=true

**Description**: [See https://app.asana.com/1/137249556945/task/1207771834161183/comment/1212653782657205?focus=true](https://app.asana.com/1/137249556945/inbox/1201807753392396/item/1213798658770663/story/1213959867935991)

**Testing**:

Validate Survey target is updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adjusts survey rollout targeting; no code or security-sensitive logic changes.
> 
> **Overview**
> Bumps `android-config.json` version to `99` and reduces the `targetPercentile.before` for rule `id: 2` (net attribute rating survey D0–3) from **30% to 10%** to lower the survey exposure rate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3420d07e7d4a28b1bcd7d679503cb59f6a6371f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->