### PR TITLE
iOS & macOS Q2 2026 satisfaction survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 103,
+  "version": 104,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -376,8 +376,31 @@
         19
       ],
       "exclusionRules": []
+    },
+    {
+      "id": "ios_quarterly_satisfaction_survey_q2_2026",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help us improve the app!",
+        "descriptionText": "Take our short anonymous survey and share your feedback.",
+        "placeholder": "Announce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240903?list=12",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;locale;last_search_state"
+          }
+        }
+      },
+      "matchingRules": [
+        20
+      ],
+      "exclusionRules": [
+        1, 2, 17, 18, 21
+      ]
     }
- ],
+  ],
   "rules": [
     {
       "id": 1,
@@ -798,6 +821,42 @@
       "attributes": {
         "shouldShowWinBackOfferUrgencyMessage": {
           "value": true
+        }
+      }
+    },
+
+    {
+      "id": 20,
+      "targetPercentile": {
+        "before": 0.2
+      },
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        },
+        "appVersion": {
+          "min": "7.123.0.0"
+        }
+      }
+    },
+    {
+      "id": 21,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": [
+            "ddg_ios_survey_1",
+            "ios_quarterly_satisfaction_survey_q4_2025"
+          ]
+        },
+        "messageShown": {
+          "value": [
+            "ddg_ios_survey_1"
+          ]
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -397,7 +397,7 @@
         20
       ],
       "exclusionRules": [
-        1, 2, 17, 18, 21
+        1, 2, 17, 18, 21, 22
       ]
     }
   ],
@@ -852,7 +852,12 @@
             "ddg_ios_survey_1",
             "ios_quarterly_satisfaction_survey_q4_2025"
           ]
-        },
+        }
+      }
+    },
+    {
+      "id": 22,
+      "attributes": {
         "messageShown": {
           "value": [
             "ddg_ios_survey_1"

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 49,
+  "version": 50,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",
@@ -414,6 +414,26 @@
         "placeholder": "CriticalUpdate"
       },
       "matchingRules": [10]
+    },
+
+    {
+      "id": "macos_quarterly_satisfaction_survey_q2_2026",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve",
+        "descriptionText": "We really want to know which features would make our browser better.",
+        "placeholder": "Announce",
+        "primaryActionText": "Tell Us What You Think",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/250206?list=7",
+          "additionalParameters": {
+            "queryParams": "delta;var;osv;ddgv;last_search_state"
+          }
+        }
+      },
+      "matchingRules": [25],
+      "exclusionRules": [26]
     }
   ],
   "rules": [
@@ -865,6 +885,40 @@
         },
         "osApi": {
           "max": "14.999.999"
+        }
+      }
+    },
+
+    {
+      "id": 25,
+      "targetPercentile": {
+        "before": 0.3
+      },
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        },
+        "appVersion": {
+          "min": "1.146.0"
+        },
+        "daysSinceInstalled": {
+          "min": 28
+        }
+      }
+    },
+    {
+      "id": 26,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": [
+            "macos_permanent_survey_tab_bar",
+            "macos_quarterly_satisfaction_survey_q4_2025"
+          ]
         }
       }
     }


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/1/137249556945/task/1213962528224237?focus=true

This PR adds the iOS & macOS Q2 2026 satisfaction surveys.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds new remote survey messages and gating rules; main risk is unintended targeting/exclusion causing the survey to show to the wrong cohort or too frequently.
> 
> **Overview**
> Adds new Q2 2026 quarterly satisfaction survey remote messages for iOS and macOS, including updated survey URLs and query parameters.
> 
> Updates both platform configs’ `version` and introduces new targeting/exclusion rules to control rollout (percentile gating, locale/app-version requirements, and suppression if users have already seen or interacted with prior survey messages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8580c963e9e951e607175cc1c8dd723827d4a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->