### PR TITLE
Added d0 NAR survey remote message

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,6 +1,27 @@
 {
-  "version": 54,
+  "version": 55,
   "messages": [
+    {
+      "id": "windows_onboarding_v4_survey",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve",
+        "descriptionText": "Take our short survey and help us build the best browser.",
+        "placeholder": "Announce",
+        "primaryActionText": "Share Your Thoughts",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/260400?list=1",
+          "additionalParameters": {
+            "queryParams": "wv;atb;ddgv;sts;var;origin;last_search_state"
+          }
+        }
+      },
+      "matchingRules": [
+        13
+      ],
+      "exclusionRules": []
+    },
     {
       "id": "windows_privacy_pro_exit_survey_1",
       "content": {
@@ -71,7 +92,7 @@
         10
       ],
       "exclusionRules": [
-        11
+        11,14
       ]
     }
   ],
@@ -186,7 +207,7 @@
     {
       "id": 10,
       "targetPercentile": {
-        "before": 0.5
+        "before": 0.75
       },
       "attributes": {
         "daysSinceInstalled": {
@@ -230,6 +251,34 @@
         },
         "daysSinceDuckAiUsed": {
           "max": 7
+        }
+      }
+    },
+    {
+      "id": 13,
+      "targetPercentile": {
+        "before": 0.5
+      },
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 0,
+          "max": 3
+        },
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        }
+      }
+    },
+    {
+      "id": 14,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": [ "windows_onboarding_v4_survey"]
         }
       }
     }


### PR DESCRIPTION
This adds https://app.asana.com/1/137249556945/project/1207619243206445/task/1213914521456752.

This should show for half of english speaking users who installed the browser within the last 0-3 days.

This also reduces the display of the 14 day survey to 25% of users who did not interact with the above survey

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it alters remote message targeting percentages and exclusion rules which can impact how many users see surveys.
> 
> **Overview**
> Bumps `live/windows-config/windows-config.json` to version `55` and adds a new remote message survey (`windows_onboarding_v4_survey`) targeting English locales within 0–3 days of install (50% rollout via new rule `13`).
> 
> Adjusts the existing `windows_14_day_survey` by changing its rollout targeting and excluding users who interacted with the new onboarding survey (new rule `14` + added to `exclusionRules`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ae939dfb2504803a0a8afefdaf76ee304ec6e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->