### PR TITLE
Android: Add quarterly browser survey Q2 26

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 99,
+  "version": 100,
   "messages": [
     {
       "id": "android_deprecation_early_notice_os8",
@@ -412,6 +412,29 @@
       "matchingRules": [
         2
       ]
+    },
+    {
+      "id": "android_quarterly_mobile_survey_q226",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help us improve the app!",
+        "descriptionText": "Take our short anonymous survey and share your feedback.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240903?list=13",
+          "additionalParameters": {
+            "queryParams": "var;delta;av;ddgv;locale"
+          }
+        }
+      },
+      "exclusionRules": [
+        6, 7, 10
+      ],
+      "matchingRules": [
+        9
+      ]
     }
   ],
   "rules": [
@@ -553,6 +576,35 @@
         "interactedWithMessage": {
           "value": [
             "android_privacy_pro_exit_survey_1"
+          ]
+        }
+      }
+    },
+    {
+      "id": 9,
+      "targetPercentile": {
+        "before": 0.2
+      },
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        }
+      }
+    },
+    {
+      "id": 10,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": [
+            "android_survey_net_attribute_rating_d0_3",
+            "android_permanent_survey_user_satisfaction",
+            "android_quarterly_mobile_survey_q425",
+            "android_day0_onboarding_design_experiment_survey"
           ]
         }
       }


### PR DESCRIPTION
**Asana**: https://app.asana.com/1/137249556945/task/1213962526828365?focus=true

**Description**: https://app.asana.com/1/137249556945/project/1207619243206445/task/1213959862817212?focus=true

**Testing**:
Validate survey shows for qualified users

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that adds a new in-app survey message and targeting/exclusion rules; main risk is unintended user targeting or over/under-delivery if rule logic is misconfigured.
> 
> **Overview**
> Adds a new Android in-app message `android_quarterly_mobile_survey_q226` pointing to the Q2’26 quarterly survey, including updated query parameters.
> 
> Introduces new targeting/exclusion rules (new rule IDs `9` and `10`) to limit the survey to a 20% slice of selected English locales and to suppress it for users who are Privacy Pro subscribers or who have already interacted with other surveys/messages. Bumps config `version` to `100`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5519df224588579d09987bbe8cf5c6e5d690dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->