### PR TITLE
Android: Remove quarterly browser survey Q2 26

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 100,
+  "version": 101,
   "messages": [
     {
       "id": "android_deprecation_early_notice_os8",
@@ -412,29 +412,6 @@
       "matchingRules": [
         2
       ]
-    },
-    {
-      "id": "android_quarterly_mobile_survey_q226",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "DDGAnnounce",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240903?list=13",
-          "additionalParameters": {
-            "queryParams": "var;delta;av;ddgv;locale"
-          }
-        }
-      },
-      "exclusionRules": [
-        6, 7, 10
-      ],
-      "matchingRules": [
-        9
-      ]
     }
   ],
   "rules": [
@@ -576,35 +553,6 @@
         "interactedWithMessage": {
           "value": [
             "android_privacy_pro_exit_survey_1"
-          ]
-        }
-      }
-    },
-    {
-      "id": 9,
-      "targetPercentile": {
-        "before": 0.2
-      },
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
-          ]
-        }
-      }
-    },
-    {
-      "id": 10,
-      "attributes": {
-        "interactedWithMessage": {
-          "value": [
-            "android_survey_net_attribute_rating_d0_3",
-            "android_permanent_survey_user_satisfaction",
-            "android_quarterly_mobile_survey_q425",
-            "android_day0_onboarding_design_experiment_survey"
           ]
         }
       }


### PR DESCRIPTION
**Asana**: https://app.asana.com/1/137249556945/task/1213965663239482

**Description**:
https://app.asana.com/1/137249556945/project/1207619243206445/task/1213959862817212?focus=true

**Testing**:
Check that the survey is correctly removed based on the diff of the original PR https://github.com/duckduckgo/remote-messaging-config/pull/346.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that deletes a single message and its associated rules; primary risk is unintended targeting changes if downstream references expected those rule IDs.
> 
> **Overview**
> Removes the `android_quarterly_mobile_survey_q226` remote message from `live/android-config/android-config.json`, along with the now-unused targeting/exclusion rules (`id` 9 and 10) that supported it.
> 
> Bumps the Android config `version` from `100` to `101` to publish the update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5681a8781135eae847b0db25e8a627648a58b2b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->