### PR TITLE
added q2 2026 survey for windows

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -23,6 +23,29 @@
       "exclusionRules": []
     },
     {
+      "id": "windows_quarterly_satisfaction_survey_q2_26",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve",
+        "descriptionText": "We'd love to know which features would make our browser better.",
+        "placeholder": "Announce",
+        "primaryActionText": "Tell Us What You Think",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/250206?list=8",
+          "additionalParameters": {
+            "queryParams": "wv;delta;ddgv;sts;var;last_search_state"
+          }
+        }
+      },
+      "matchingRules": [
+        15
+      ],
+      "exclusionRules": [
+        16
+      ]
+    },
+    {
       "id": "windows_privacy_pro_exit_survey_1",
       "content": {
         "messageType": "big_single_action",
@@ -92,7 +115,8 @@
         10
       ],
       "exclusionRules": [
-        11,14
+        11,
+        14
       ]
     }
   ],
@@ -278,7 +302,31 @@
       "id": 14,
       "attributes": {
         "interactedWithMessage": {
-          "value": [ "windows_onboarding_v4_survey"]
+          "value": [ "windows_onboarding_v4_survey" ]
+        }
+      }
+    },
+    {
+      "id": 15,
+      "targetPercentile": {
+        "before": 0.5
+      },
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        }
+      }
+    },
+    {
+      "id": 16,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": [ "windows_onboarding_v4_survey", "windows_14_day_survey", "windows_quarterly_satisfaction_survey_q4_25" ]
         }
       }
     }


### PR DESCRIPTION
See https://app.asana.com/1/137249556945/project/1207619243206445/task/1213959862817227 for details

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that adds a new survey message and targeting/exclusion rules; main risk is incorrect rule gating or survey URL/query params causing unintended prompting.
> 
> **Overview**
> Adds a new Windows in-app message `windows_quarterly_satisfaction_survey_q2_26` that links to a Decipher survey and sends a slightly different set of query parameters.
> 
> Introduces new rule IDs `15` (locale + 50% targeting) and `16` (exclude users who have already interacted with recent survey messages), and wires the new message to these rules; also normalizes formatting in an existing exclusion list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a8c013be600de96b5d3d5c3fec9899188c2d9b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->