### PR TITLE
Remove iOS 2026 Q2 survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 104,
+  "version": 105,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -376,29 +376,6 @@
         19
       ],
       "exclusionRules": []
-    },
-    {
-      "id": "ios_quarterly_satisfaction_survey_q2_2026",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "Announce",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240903?list=12",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;locale;last_search_state"
-          }
-        }
-      },
-      "matchingRules": [
-        20
-      ],
-      "exclusionRules": [
-        1, 2, 17, 18, 21, 22
-      ]
     }
   ],
   "rules": [
@@ -821,47 +798,6 @@
       "attributes": {
         "shouldShowWinBackOfferUrgencyMessage": {
           "value": true
-        }
-      }
-    },
-
-    {
-      "id": 20,
-      "targetPercentile": {
-        "before": 0.2
-      },
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
-          ]
-        },
-        "appVersion": {
-          "min": "7.123.0.0"
-        }
-      }
-    },
-    {
-      "id": 21,
-      "attributes": {
-        "interactedWithMessage": {
-          "value": [
-            "ddg_ios_survey_1",
-            "ios_quarterly_satisfaction_survey_q4_2025"
-          ]
-        }
-      }
-    },
-    {
-      "id": 22,
-      "attributes": {
-        "messageShown": {
-          "value": [
-            "ddg_ios_survey_1"
-          ]
         }
       }
     }


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/1/137249556945/task/1213962528224241?focus=true

This PR removes the iOS survey that was added in https://github.com/duckduckgo/remote-messaging-config/pull/344.

**How to test:**
1. Check that the survey was removed correctly when comparing to the original PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that disables a specific survey message by removing its message entry and targeting/exclusion rules.
> 
> **Overview**
> **Disables the iOS Q2 2026 quarterly satisfaction survey** by removing the `ios_quarterly_satisfaction_survey_q2_2026` message and its associated targeting/exclusion rules (`id` 20–22) from `ios-config.json`.
> 
> Bumps the iOS config `version` from `104` to `105` so clients pick up the removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c21c2333a7ee16a4f47adb11b2477d00dc77c168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->