### PR TITLE
Increase macOS Q2 2026 survey rollout to 50%

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 50,
+  "version": 51,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",
@@ -892,7 +892,7 @@
     {
       "id": 25,
       "targetPercentile": {
-        "before": 0.3
+        "before": 0.5
       },
       "attributes": {
         "locale": {


### PR DESCRIPTION
This PR increases the macOS Q2 survey rollout to 50%, as requested [here](https://app.asana.com/1/137249556945/task/1213959862817234/comment/1214152717966679?focus=true).

**How to test:**
1. Check that the correct rule has been updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that increases the audience for an existing macOS survey message; main risk is unintended rollout reach if the percentile gate is incorrect.
> 
> **Overview**
> Bumps `live/macos-config/macos-config.json` config `version` to `51` and increases rule `25`’s `targetPercentile.before` from `0.3` to `0.5`, expanding the macOS Q2 2026 quarterly satisfaction survey rollout to 50% of the targeted cohort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5bc400afb11ac260a057748718c1819b564f446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->