### PR TITLE
Update net attribute rating survey target to 5%

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 101,
+  "version": 102,
   "messages": [
     {
       "id": "android_deprecation_early_notice_os8",
@@ -441,7 +441,7 @@
     {
       "id": 2,
       "targetPercentile": {
-        "before": 0.1
+        "before": 0.05
       },
       "attributes": {
         "locale": {


### PR DESCRIPTION
**Asana**: https://app.asana.com/1/137249556945/task/1214218183708826?focus=true

**Description**: See https://app.asana.com/1/137249556945/inbox/1201807753392396/item/1213798658770663/story/1211195578398899

**Testing**:
Validate Survey target is updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change that reduces the rollout percentage for an in-app survey; no code or data-handling logic is modified.
> 
> **Overview**
> Updates `live/android-config/android-config.json` to bump the config `version` to `102` and reduce rule `id: 2` `targetPercentile.before` from `0.1` to `0.05`, lowering targeting for the `android_survey_net_attribute_rating_d0_3` survey.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a733e3409c3564d4110bcf96123b2d83e0df80a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->