### PR TITLE
Removed windows Q2 2026 survey

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 55,
+  "version": 56,
   "messages": [
     {
       "id": "windows_onboarding_v4_survey",
@@ -21,29 +21,6 @@
         13
       ],
       "exclusionRules": []
-    },
-    {
-      "id": "windows_quarterly_satisfaction_survey_q2_26",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help Us Improve",
-        "descriptionText": "We'd love to know which features would make our browser better.",
-        "placeholder": "Announce",
-        "primaryActionText": "Tell Us What You Think",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/250206?list=8",
-          "additionalParameters": {
-            "queryParams": "wv;delta;ddgv;sts;var;last_search_state"
-          }
-        }
-      },
-      "matchingRules": [
-        15
-      ],
-      "exclusionRules": [
-        16
-      ]
     },
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -303,30 +280,6 @@
       "attributes": {
         "interactedWithMessage": {
           "value": [ "windows_onboarding_v4_survey" ]
-        }
-      }
-    },
-    {
-      "id": 15,
-      "targetPercentile": {
-        "before": 0.5
-      },
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
-          ]
-        }
-      }
-    },
-    {
-      "id": 16,
-      "attributes": {
-        "interactedWithMessage": {
-          "value": [ "windows_onboarding_v4_survey", "windows_14_day_survey", "windows_quarterly_satisfaction_survey_q4_25" ]
         }
       }
     }


### PR DESCRIPTION
This removes https://app.asana.com/1/137249556945/project/1207619243206445/task/1213959862817227

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change that removes a survey message and its targeting/exclusion rules; main impact is reduced survey prompting for affected cohorts.
> 
> **Overview**
> **Removes** the `windows_quarterly_satisfaction_survey_q2_26` in-app survey from `windows-config.json`, including its associated targeting/exclusion rules.
> 
> Bumps the Windows config `version` from `55` to `56` to publish the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12bbddcc2063bb6e56e9b986caa34f4084bc47e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->