### PR TITLE
Remove the macOS Q2 2026 survey

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 52,
+  "version": 53,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",
@@ -414,26 +414,6 @@
         "placeholder": "CriticalUpdate"
       },
       "matchingRules": [10]
-    },
-
-    {
-      "id": "macos_quarterly_satisfaction_survey_q2_2026",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help Us Improve",
-        "descriptionText": "We really want to know which features would make our browser better.",
-        "placeholder": "Announce",
-        "primaryActionText": "Tell Us What You Think",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/250206?list=7",
-          "additionalParameters": {
-            "queryParams": "delta;var;osv;ddgv;last_search_state"
-          }
-        }
-      },
-      "matchingRules": [25],
-      "exclusionRules": [26]
     },
     {
       "id": "macos_update_app_appstore",
@@ -999,40 +979,6 @@
         },
         "osApi": {
           "max": "14.999.999"
-        }
-      }
-    },
-
-    {
-      "id": 25,
-      "targetPercentile": {
-        "before": 0.5
-      },
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
-          ]
-        },
-        "appVersion": {
-          "min": "1.146.0"
-        },
-        "daysSinceInstalled": {
-          "min": 28
-        }
-      }
-    },
-    {
-      "id": 26,
-      "attributes": {
-        "interactedWithMessage": {
-          "value": [
-            "macos_permanent_survey_tab_bar",
-            "macos_quarterly_satisfaction_survey_q4_2025"
-          ]
         }
       }
     },


### PR DESCRIPTION
Removes the macOS survey that was added here: https://github.com/duckduckgo/remote-messaging-config/pull/344

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change: removes a single survey message and its targeting rules, with no code or logic changes.
> 
> **Overview**
> Removes the `macos_quarterly_satisfaction_survey_q2_2026` remote message from `macos-config.json` along with its associated targeting/exclusion rules (`25`/`26`), preventing this survey from being shown going forward.
> 
> Bumps the macOS config `version` from `52` to `53` to publish the updated message set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eee845d2d5ebe3bc0ff0c525871a2c33eeffbc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->