### PR TITLE
[macOS] Remove old manual update message & associated rule

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 53,
+  "version": 54,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",
@@ -406,16 +406,6 @@
       "exclusionRules": []
     },
     {
-      "id": "macos_switch_to_manual_updates",
-      "content": {
-        "messageType": "medium",
-        "titleText": "Automatic Update Failed",
-        "descriptionText": "To get the latest version, go to Settings > About, and turn on manual updates. Then click Restart To Update.",
-        "placeholder": "CriticalUpdate"
-      },
-      "matchingRules": [10]
-    },
-    {
       "id": "macos_update_app_appstore",
       "content": {
         "messageType": "big_single_action",
@@ -660,18 +650,6 @@
       "attributes": {
         "interactedWithDeprecatedMacRemoteMessage": {
           "value": ["privacy_pro_survey_1"]
-        }
-      }
-    },
-    {
-      "id": 10,
-      "attributes": {
-        "appVersion": {
-          "min": "1.99.0",
-          "max": "1.102.0"
-        },
-        "installedMacAppStore": {
-          "value": false
         }
       }
     },


### PR DESCRIPTION
Task: https://app.asana.com/1/137249556945/project/1201462886803403/task/1208340098560916?focus=true

Description:
Removes message added in https://github.com/duckduckgo/remote-messaging-config/pull/109

Test steps:
Confirm message with id `macos_switch_to_manual_updates ` and associated rule id `10` have been removed from the config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that removes an obsolete remote message and its targeting rule; impact is limited to which update prompt users may see.
> 
> **Overview**
> Bumps `live/macos-config/macos-config.json` version to `54` and removes the deprecated remote message `macos_switch_to_manual_updates` ("Automatic Update Failed").
> 
> Also deletes the associated targeting rule `id: 10` (app version range + non–Mac App Store installs), so this message can no longer be served.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25cd67dd235dd93b81d2080df4c2836c9a52b245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->