### PR TITLE
Add iOS PIR freemium RMFs

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -869,7 +869,7 @@
       "id": 20,
       "attributes": {
         "appVersion": {
-          "min": "7.218.0"
+          "min": "7.220.0"
         },
         "isFreemiumPIREligible": {
           "value": true
@@ -883,7 +883,7 @@
       "id": 21,
       "attributes": {
         "appVersion": {
-          "min": "7.218.0"
+          "min": "7.220.0"
         },
         "isFreemiumPIREligible": {
           "value": true
@@ -897,7 +897,7 @@
       "id": 22,
       "attributes": {
         "appVersion": {
-          "min": "7.218.0"
+          "min": "7.220.0"
         },
         "isFreemiumPIREligible": {
           "value": true

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -868,9 +868,6 @@
     {
       "id": 20,
       "attributes": {
-        "appVersion": {
-          "min": "7.220.0"
-        },
         "isFreemiumPIREligible": {
           "value": true
         },
@@ -882,9 +879,6 @@
     {
       "id": 21,
       "attributes": {
-        "appVersion": {
-          "min": "7.220.0"
-        },
         "isFreemiumPIREligible": {
           "value": true
         },
@@ -896,9 +890,6 @@
     {
       "id": 22,
       "attributes": {
-        "appVersion": {
-          "min": "7.220.0"
-        },
         "isFreemiumPIREligible": {
           "value": true
         },

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 106,
+  "version": 107,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -372,6 +372,48 @@
       },
       "matchingRules": [
         20
+      ],
+      "exclusionRules": []
+    },
+    {
+      "id": "ios_pir_freemium_scan_complete_results",
+      "surfaces": [
+        "new_tab_page"
+      ],
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Personal Information Removal",
+        "descriptionText": "Your free personal info scan found records about you.",
+        "placeholder": "PIR",
+        "primaryActionText": "View Results",
+        "primaryAction": {
+          "type": "navigation",
+          "value": "pir.main"
+        }
+      },
+      "matchingRules": [
+        21
+      ],
+      "exclusionRules": []
+    },
+    {
+      "id": "ios_pir_freemium_scan_complete_no_results",
+      "surfaces": [
+        "new_tab_page"
+      ],
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Personal Information Removal",
+        "descriptionText": "Good news, your free personal info scan didn't find any records about you. We'll keep checking periodically.",
+        "placeholder": "PIR",
+        "primaryActionText": "View Results",
+        "primaryAction": {
+          "type": "navigation",
+          "value": "pir.main"
+        }
+      },
+      "matchingRules": [
+        22
       ],
       "exclusionRules": []
     },
@@ -831,6 +873,37 @@
         },
         "isFreemiumPIREligible": {
           "value": true
+        },
+        "freemiumPIRDidActivate": {
+          "value": false
+        }
+      }
+    },
+    {
+      "id": 21,
+      "attributes": {
+        "appVersion": {
+          "min": "7.218.0"
+        },
+        "isFreemiumPIREligible": {
+          "value": true
+        },
+        "freemiumPIRFirstScanResult": {
+          "value": "matchesFound"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "attributes": {
+        "appVersion": {
+          "min": "7.218.0"
+        },
+        "isFreemiumPIREligible": {
+          "value": true
+        },
+        "freemiumPIRFirstScanResult": {
+          "value": "noMatches"
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 105,
+  "version": 106,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -352,6 +352,28 @@
       "matchingRules": [
         4
       ]
+    },
+
+    {
+      "id": "ios_pir_freemium_entry_point",
+      "surfaces": [
+        "new_tab_page"
+      ],
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Personal Information Removal",
+        "descriptionText": "Find your personal info on sites that sell it.",
+        "placeholder": "PIR",
+        "primaryActionText": "Free Scan",
+        "primaryAction": {
+          "type": "navigation",
+          "value": "pir.main"
+        }
+      },
+      "matchingRules": [
+        20
+      ],
+      "exclusionRules": []
     },
 
     {
@@ -797,6 +819,17 @@
       "id": 19,
       "attributes": {
         "shouldShowWinBackOfferUrgencyMessage": {
+          "value": true
+        }
+      }
+    },
+    {
+      "id": 20,
+      "attributes": {
+        "appVersion": {
+          "min": "7.218.0"
+        },
+        "isFreemiumPIREligible": {
           "value": true
         }
       }

--- a/schemas/ios/schema.json
+++ b/schemas/ios/schema.json
@@ -392,6 +392,8 @@
             "messageShown": { "$ref": "#/definitions/SingleValueStringArrayAttribute" },
             "isCurrentFreemiumPIRUser": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
             "isFreemiumPIREligible": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
+            "freemiumPIRDidActivate": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
+            "freemiumPIRFirstScanResult": { "$ref": "#/definitions/SingleValueStringAttribute" },
             "isCurrentPIRUser": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
             "allFeatureFlagsEnabled": { "$ref": "#/definitions/SingleValueStringArrayAttribute" },
             "subscriptionFreeTrialActive": { "$ref": "#/definitions/SingleValueBooleanAttribute" },

--- a/schemas/ios/schema.json
+++ b/schemas/ios/schema.json
@@ -391,6 +391,7 @@
             "duckPlayerEnabled": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
             "messageShown": { "$ref": "#/definitions/SingleValueStringArrayAttribute" },
             "isCurrentFreemiumPIRUser": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
+            "isFreemiumPIREligible": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
             "isCurrentPIRUser": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
             "allFeatureFlagsEnabled": { "$ref": "#/definitions/SingleValueStringArrayAttribute" },
             "subscriptionFreeTrialActive": { "$ref": "#/definitions/SingleValueBooleanAttribute" },


### PR DESCRIPTION
Asana: https://app.asana.com/1/137249556945/project/72649045549333/task/1210938375848291

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config/schema-only changes that gate new iOS remote messages behind new matching-rule attributes, with no code execution or security-sensitive logic changes.
> 
> **Overview**
> Adds three new iOS Remote Message Framework cards on the `new_tab_page` to promote PIR freemium: an entry point CTA plus separate scan-complete messages for *matches found* vs *no matches*, all navigating to `pir.main`.
> 
> Bumps `ios-config.json` version to `107` and introduces new rule attributes (`isFreemiumPIREligible`, `freemiumPIRDidActivate`, `freemiumPIRFirstScanResult`) with corresponding rules (`20`–`22`), updating the iOS JSON schema to allow these attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dddce46e2a80b756906ba57cc9ede98add68598c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->