### PR TITLE
Android: Replace deprecation early notice with urgent notice

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,23 +1,23 @@
 {
-  "version": 102,
+  "version": 103,
   "messages": [
     {
-      "id": "android_deprecation_early_notice_os8",
+      "id": "android_deprecation_urgent_notice_os8",
       "content": {
         "messageType": "medium",
-        "titleText": "Important: Upgrade to Android 9 or higher to stay protected",
-        "descriptionText": "From June 9, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
-        "placeholder": "Announce"
+        "titleText": "Important reminder: Upgrade to Android 9 or higher to stay protected",
+        "descriptionText": "After June 9, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
+        "placeholder": "CriticalUpdate"
       },
       "matchingRules": [25]
     },
     {
-      "id": "android_deprecation_early_notice_os8_ppro",
+      "id": "android_deprecation_urgent_notice_os8_ppro",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Important: Upgrade to Android 9 or request subscription refund",
-        "descriptionText": "From June 9, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
-        "placeholder": "Announce",
+        "titleText": "Important reminder: Upgrade to Android 9 or request subscription refund",
+        "descriptionText": "After June 9, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
+        "placeholder": "CriticalUpdate",
         "primaryActionText": "Request Subscription Refund",
         "primaryAction": {
           "type": "url",


### PR DESCRIPTION
Task: https://app.asana.com/1/137249556945/project/414730916066338/task/1213465361640432?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that updates in-app messaging copy/IDs/placeholders; main risk is mismatched `id`/placeholder expectations causing the wrong message variant to display.
> 
> **Overview**
> Bumps `live/android-config/android-config.json` config `version` to `103` and replaces the Android 8/8.1 deprecation *early notice* messages with *urgent notice* variants.
> 
> Updates the two message `id`s, adjusts title/description copy ("From" → "After" June 9, 2026 wording), and changes the message `placeholder` from `Announce` to `CriticalUpdate` (including the Privacy Pro refund CTA message).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911fd0d83f57e8014c537fbeaf2afa934503b3b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->