### PR TITLE
[macOS] Add Big Sur support-dropped notice (untargeted, draft)

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 54,
+  "version": 55,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",
@@ -518,6 +518,20 @@
         }
       },
       "matchingRules": [28]
+    },
+    {
+      "id": "macos_big_sur_support_dropped",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "macOS Big Sur support is ending",
+        "descriptionText": "Future DuckDuckGo updates require macOS Monterey or later. Update macOS to keep getting new features, fixes, and security improvements.",
+        "placeholder": "VeryCriticalUpdate",
+        "primaryActionText": "Update macOS",
+        "primaryAction": {
+          "type": "navigation",
+          "value": "softwareUpdate"
+        }
+      }
     }
   ],
   "rules": [

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 55,
+  "version": 56,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",
@@ -531,6 +531,15 @@
           "type": "navigation",
           "value": "softwareUpdate"
         }
+      }
+    },
+    {
+      "id": "macos_big_sur_support_dropped_no_cta",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Big Sur support has ended",
+        "descriptionText": "DuckDuckGo updates have ended for macOS Big Sur. Your browser will keep working as it does today.",
+        "placeholder": "VeryCriticalUpdate"
       }
     }
   ],

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -680,7 +680,7 @@
       "id": 12,
       "attributes": {
         "appVersion": {
-          "min": "1.121.0"
+          "min": "9999.0.0"
         },
         "daysSinceInstalled": {
           "min": 14,

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -523,8 +523,8 @@
       "id": "macos_big_sur_support_dropped",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "macOS Big Sur support is ending",
-        "descriptionText": "Future DuckDuckGo updates require macOS Monterey or later. Update macOS to keep getting new features, fixes, and security improvements.",
+        "titleText": "DuckDuckGo no longer supports macOS Big Sur",
+        "descriptionText": "Update macOS to Monterey or later to keep getting new DuckDuckGo features, fixes, and security improvements.",
         "placeholder": "VeryCriticalUpdate",
         "primaryActionText": "Update macOS",
         "primaryAction": {

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -523,7 +523,7 @@
       "id": "macos_big_sur_support_dropped",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "DuckDuckGo no longer supports macOS Big Sur",
+        "titleText": "Big Sur support has ended",
         "descriptionText": "Update macOS to Monterey or later to keep getting new DuckDuckGo features, fixes, and security improvements.",
         "placeholder": "VeryCriticalUpdate",
         "primaryActionText": "Update macOS",


### PR DESCRIPTION
Adds a placeholder message announcing the end of macOS Big Sur support. Currently has no matchingRules so it shows to all users — an osApi rule limiting it to Big Sur will be added before publishing.