### PR TITLE
removed new onboarding survey. Also cleaned up some unused rules

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,27 +1,6 @@
 {
-  "version": 56,
+  "version": 57,
   "messages": [
-    {
-      "id": "windows_onboarding_v4_survey",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help Us Improve",
-        "descriptionText": "Take our short survey and help us build the best browser.",
-        "placeholder": "Announce",
-        "primaryActionText": "Share Your Thoughts",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/260400?list=1",
-          "additionalParameters": {
-            "queryParams": "wv;atb;ddgv;sts;var;origin;last_search_state"
-          }
-        }
-      },
-      "matchingRules": [
-        13
-      ],
-      "exclusionRules": []
-    },
     {
       "id": "windows_privacy_pro_exit_survey_1",
       "content": {
@@ -98,18 +77,6 @@
     }
   ],
   "rules": [
-    {
-      "id": 1,
-      "targetPercentile": {
-        "before": 0.80
-      },
-      "attributes": {
-        "daysSinceInstalled": {
-          "min": 14,
-          "max": 10000
-        }
-      }
-    },
     {
       "id": 2,
       "attributes": {
@@ -198,14 +165,6 @@
       }
     },
     {
-      "id": 9,
-      "attributes": {
-        "flavor": {
-          "value": [ "beta", "dev", "canary", "preview" ]
-        }
-      }
-    },
-    {
       "id": 10,
       "targetPercentile": {
         "before": 0.75
@@ -234,43 +193,6 @@
         "interactedWithDeprecatedWindowsSurvey": {
           "value": [
             "survey.dismissed"
-          ]
-        }
-      }
-    },
-    {
-      "id": 12,
-      "attributes": {
-        "pproSubscriber": {
-          "value": false
-        },
-        "pproEligible": {
-          "value": true
-        },
-        "locale": {
-          "value": [ "en-US" ]
-        },
-        "daysSinceDuckAiUsed": {
-          "max": 7
-        }
-      }
-    },
-    {
-      "id": 13,
-      "targetPercentile": {
-        "before": 0.5
-      },
-      "attributes": {
-        "daysSinceInstalled": {
-          "min": 0,
-          "max": 3
-        },
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
           ]
         }
       }


### PR DESCRIPTION
Removed the message that was added in https://github.com/duckduckgo/remote-messaging-config/pull/345. See https://app.asana.com/1/137249556945/project/1207619243206445/task/1213914521456752

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk config-only change removing a survey message and several targeting rules; main risk is unintended messaging eligibility changes due to deleted rules and lingering references to the removed message id.
> 
> **Overview**
> Bumps `live/windows-config/windows-config.json` to version `57` and removes the `windows_onboarding_v4_survey` message from the Windows remote messaging configuration.
> 
> Cleans up unused/legacy rules (`id` 1, 9, 12, 13), which changes the set of attributes/percentiles used to gate Windows survey messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44818b921a71df2324d60d160bff2d8e0c42c70c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->