### PR TITLE
Update net attribute rating survey target to 10%

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 103,
+  "version": 104,
   "messages": [
     {
       "id": "android_deprecation_urgent_notice_os8",
@@ -441,7 +441,7 @@
     {
       "id": 2,
       "targetPercentile": {
-        "before": 0.05
+        "before": 0.1
       },
       "attributes": {
         "locale": {


### PR DESCRIPTION
**Asana**: https://app.asana.com/1/137249556945/task/1215096936507721?focus=true

**Description**: See https://app.asana.com/1/137249556945/task/1213798658770663/comment/1215042202658192?focus=true

**Testing**:
Validate Survey target is updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only targeting tweak for an in-app survey; no app logic, auth, or data handling changes.
> 
> **Overview**
> Bumps **Android remote config** version **103 → 104** and doubles rollout for the **day-0–3 net attribute rating** survey (`android_survey_net_attribute_rating_d0_3`).
> 
> **Rule 2** `targetPercentile.before` changes from **0.05 → 0.1**, so up to **10%** (was 5%) of eligible English-locale users within **3 days** of install can see the survey prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0431e87a16ed65a1861e3cd4c60bb8e2c0f6e07f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->