### PR TITLE
[macOS] Declare canUpgradeOS matching attribute in schema

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -290,64 +290,6 @@
       "matchingRules": [12]
     },
     {
-      "id": "macos_very_critical_update",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Updating macOS is recommended",
-        "descriptionText": "If a system update is available it may fix site loading issues and enhance security.",
-        "placeholder": "VeryCriticalUpdate",
-        "primaryActionText": "Update macOS",
-        "primaryAction": {
-          "type": "navigation",
-          "value": "softwareUpdate"
-        }
-      },
-      "translations": {
-        "fr": {
-          "titleText": "La mise à jour de macOS est recommandée",
-          "descriptionText": "Si une mise à jour système est disponible, elle peut corriger des problèmes de chargement de sites web et renforcer la sécurité.",
-          "primaryActionText": "Mettre à jour macOS"
-        },
-        "de": {
-          "titleText": "macOS-Update empfohlen",
-          "descriptionText": "Falls ein Softwareupdate verfügbar ist, kann es Probleme beim Laden von Webseiten beheben und die Sicherheit verbessern.",
-          "primaryActionText": "macOS aktualisieren"
-        },
-        "nl": {
-          "titleText": "Het wordt aanbevolen macOS bij te werken",
-          "descriptionText": "Als er een systeemupdate beschikbaar is, kan deze laadproblemen van websites oplossen en de beveiliging verbeteren.",
-          "primaryActionText": "macOS bijwerken"
-        },
-        "it": {
-          "titleText": "Si consiglia di aggiornare macOS",
-          "descriptionText": "Se è disponibile un aggiornamento di sistema, potrebbe risolvere i problemi di caricamento dei siti web e migliorare la sicurezza.",
-          "primaryActionText": "Aggiorna macOS"
-        },
-        "es": {
-          "titleText": "Se recomienda actualizar macOS",
-          "descriptionText": "Si hay una actualización del sistema disponible, puede solucionar problemas para cargar sitios web y mejorar la seguridad.",
-          "primaryActionText": "Actualizar macOS"
-        },
-        "pl": {
-          "titleText": "Zalecana jest aktualizacja systemu macOS",
-          "descriptionText": "Jeśli dostępna jest aktualizacja systemu, może ona rozwiązać problemy z ładowaniem stron i zwiększyć bezpieczeństwo.",
-          "primaryActionText": "Zaktualizuj macOS"
-        },
-        "ru": {
-          "titleText": "Рекомендуется обновить macOS",
-          "descriptionText": "Если доступно обновление системы, оно может устранить проблемы с загрузкой сайтов и повысить безопасность.",
-          "primaryActionText": "Обновить macOS"
-        },
-        "pt": {
-          "titleText": "É recomendável atualizar o macOS",
-          "descriptionText": "Se uma atualização do sistema estiver disponível, pode corrigir problemas de carregamento de sites e melhorar a segurança.",
-          "primaryActionText": "Atualizar macOS"
-        }
-      },
-      "matchingRules": [24],
-      "exclusionRules": []
-    },
-    {
       "id": "macos_critical_update_url",
       "content": {
         "messageType": "big_single_action",
@@ -983,17 +925,6 @@
       "attributes": {
         "appVersion": {
           "max": "1.179.0"
-        },
-        "osApi": {
-          "max": "14.999.999"
-        }
-      }
-    },
-    {
-      "id": 24,
-      "attributes": {
-        "appVersion": {
-          "min": "1.180.0"
         },
         "osApi": {
           "max": "14.999.999"

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -682,7 +682,7 @@
       "id": 12,
       "attributes": {
         "appVersion": {
-          "min": "1.121.0"
+          "min": "9999.0.0"
         },
         "daysSinceInstalled": {
           "min": 14,

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 54,
+  "version": 55,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",
@@ -518,6 +518,31 @@
         }
       },
       "matchingRules": [28]
+    },
+    {
+      "id": "macos_big_sur_eos_update_cta",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Big Sur support has ended",
+        "descriptionText": "Update macOS to Monterey or later to keep getting new DuckDuckGo features, fixes, and security improvements.",
+        "placeholder": "CriticalUpdate",
+        "primaryActionText": "Update macOS",
+        "primaryAction": {
+          "type": "url",
+          "value": "x-apple.systempreferences:com.apple.preferences.softwareupdate"
+        }
+      },
+      "matchingRules": [29]
+    },
+    {
+      "id": "macos_big_sur_eos_no_cta",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Big Sur support has ended",
+        "descriptionText": "DuckDuckGo updates have ended for macOS Big Sur. Your browser will keep working as it does today.",
+        "placeholder": "CriticalUpdate"
+      },
+      "matchingRules": [30]
     }
   ],
   "rules": [
@@ -978,6 +1003,28 @@
           "max": "1.182.0"
         },
         "installedMacAppStore": {
+          "value": false
+        }
+      }
+    },
+    {
+      "id": 29,
+      "attributes": {
+        "isInternalUser": {
+          "value": true
+        },
+        "canUpgradeOS": {
+          "value": true
+        }
+      }
+    },
+    {
+      "id": 30,
+      "attributes": {
+        "isInternalUser": {
+          "value": true
+        },
+        "canUpgradeOS": {
           "value": false
         }
       }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -525,11 +525,11 @@
         "messageType": "big_single_action",
         "titleText": "Big Sur support has ended",
         "descriptionText": "Update macOS to Monterey or later to keep getting new DuckDuckGo features, fixes, and security improvements.",
-        "placeholder": "CriticalUpdate",
+        "placeholder": "VeryCriticalUpdate",
         "primaryActionText": "Update macOS",
         "primaryAction": {
-          "type": "url",
-          "value": "x-apple.systempreferences:com.apple.preferences.softwareupdate"
+          "type": "navigation",
+          "value": "softwareUpdate"
         }
       },
       "matchingRules": [29]
@@ -540,7 +540,7 @@
         "messageType": "medium",
         "titleText": "Big Sur support has ended",
         "descriptionText": "DuckDuckGo updates have ended for macOS Big Sur. Your browser will keep working as it does today.",
-        "placeholder": "CriticalUpdate"
+        "placeholder": "VeryCriticalUpdate"
       },
       "matchingRules": [30]
     }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -474,6 +474,48 @@
           "value": "softwareUpdate"
         }
       },
+      "translations": {
+        "fr": {
+          "titleText": "La prise en charge de Big Sur est terminée",
+          "descriptionText": "Mettez à jour macOS vers Monterey ou une version ultérieure pour continuer à bénéficier des nouvelles fonctionnalités, corrections et améliorations de sécurité de DuckDuckGo.",
+          "primaryActionText": "Mettre à jour macOS"
+        },
+        "de": {
+          "titleText": "Der Support für Big Sur ist eingestellt",
+          "descriptionText": "Aktualisiere macOS auf Monterey oder neuer, um weiterhin neue DuckDuckGo-Funktionen, Fehlerbehebungen und Sicherheitsverbesserungen zu erhalten.",
+          "primaryActionText": "macOS aktualisieren"
+        },
+        "nl": {
+          "titleText": "De ondersteuning voor Big Sur is beëindigd",
+          "descriptionText": "Werk macOS bij naar Monterey of nieuwer om nieuwe DuckDuckGo-functies, oplossingen en beveiligingsverbeteringen te blijven ontvangen.",
+          "primaryActionText": "macOS bijwerken"
+        },
+        "it": {
+          "titleText": "Il supporto per Big Sur è terminato",
+          "descriptionText": "Aggiorna macOS a Monterey o versioni successive per continuare a ricevere nuove funzionalità, correzioni e miglioramenti della sicurezza di DuckDuckGo.",
+          "primaryActionText": "Aggiorna macOS"
+        },
+        "es": {
+          "titleText": "El soporte para Big Sur ha finalizado",
+          "descriptionText": "Actualiza macOS a Monterey o una versión posterior para seguir recibiendo nuevas funciones, correcciones y mejoras de seguridad de DuckDuckGo.",
+          "primaryActionText": "Actualizar macOS"
+        },
+        "pl": {
+          "titleText": "Wsparcie dla Big Sur zostało zakończone",
+          "descriptionText": "Zaktualizuj macOS do wersji Monterey lub nowszej, aby nadal otrzymywać nowe funkcje, poprawki i ulepszenia zabezpieczeń DuckDuckGo.",
+          "primaryActionText": "Zaktualizuj macOS"
+        },
+        "ru": {
+          "titleText": "Поддержка Big Sur прекращена",
+          "descriptionText": "Обновите macOS до Monterey или более новой версии, чтобы продолжать получать новые функции, исправления и улучшения безопасности DuckDuckGo.",
+          "primaryActionText": "Обновить macOS"
+        },
+        "pt": {
+          "titleText": "O suporte ao Big Sur foi encerrado",
+          "descriptionText": "Atualize o macOS para o Monterey ou posterior para continuar recebendo novos recursos, correções e melhorias de segurança do DuckDuckGo.",
+          "primaryActionText": "Atualizar macOS"
+        }
+      },
       "matchingRules": [29]
     },
     {
@@ -483,6 +525,40 @@
         "titleText": "Big Sur support has ended",
         "descriptionText": "DuckDuckGo updates have ended for macOS Big Sur. Your browser will keep working as it does today.",
         "placeholder": "VeryCriticalUpdate"
+      },
+      "translations": {
+        "fr": {
+          "titleText": "La prise en charge de Big Sur est terminée",
+          "descriptionText": "Les mises à jour de DuckDuckGo sont terminées pour macOS Big Sur. Votre navigateur continuera de fonctionner comme aujourd'hui."
+        },
+        "de": {
+          "titleText": "Der Support für Big Sur ist eingestellt",
+          "descriptionText": "Die DuckDuckGo-Updates für macOS Big Sur wurden eingestellt. Dein Browser funktioniert weiterhin wie bisher."
+        },
+        "nl": {
+          "titleText": "De ondersteuning voor Big Sur is beëindigd",
+          "descriptionText": "De DuckDuckGo-updates voor macOS Big Sur zijn beëindigd. Je browser blijft werken zoals nu."
+        },
+        "it": {
+          "titleText": "Il supporto per Big Sur è terminato",
+          "descriptionText": "Gli aggiornamenti di DuckDuckGo per macOS Big Sur sono terminati. Il tuo browser continuerà a funzionare come oggi."
+        },
+        "es": {
+          "titleText": "El soporte para Big Sur ha finalizado",
+          "descriptionText": "Las actualizaciones de DuckDuckGo para macOS Big Sur han finalizado. Tu navegador seguirá funcionando como hasta ahora."
+        },
+        "pl": {
+          "titleText": "Wsparcie dla Big Sur zostało zakończone",
+          "descriptionText": "Aktualizacje DuckDuckGo dla macOS Big Sur zostały zakończone. Twoja przeglądarka będzie nadal działać tak jak obecnie."
+        },
+        "ru": {
+          "titleText": "Поддержка Big Sur прекращена",
+          "descriptionText": "Обновления DuckDuckGo для macOS Big Sur прекращены. Ваш браузер продолжит работать так же, как сегодня."
+        },
+        "pt": {
+          "titleText": "O suporte ao Big Sur foi encerrado",
+          "descriptionText": "As atualizações do DuckDuckGo para o macOS Big Sur foram encerradas. Seu navegador continuará funcionando como hoje."
+        }
       },
       "matchingRules": [30]
     },
@@ -497,6 +573,48 @@
         "primaryAction": {
           "type": "navigation",
           "value": "softwareUpdate"
+        }
+      },
+      "translations": {
+        "fr": {
+          "titleText": "La prise en charge de Big Sur est terminée",
+          "descriptionText": "Mettez à jour macOS vers Monterey ou une version ultérieure pour continuer à bénéficier des nouvelles fonctionnalités, corrections et améliorations de sécurité de DuckDuckGo.",
+          "primaryActionText": "Mettre à jour macOS"
+        },
+        "de": {
+          "titleText": "Der Support für Big Sur ist eingestellt",
+          "descriptionText": "Aktualisiere macOS auf Monterey oder neuer, um weiterhin neue DuckDuckGo-Funktionen, Fehlerbehebungen und Sicherheitsverbesserungen zu erhalten.",
+          "primaryActionText": "macOS aktualisieren"
+        },
+        "nl": {
+          "titleText": "De ondersteuning voor Big Sur is beëindigd",
+          "descriptionText": "Werk macOS bij naar Monterey of nieuwer om nieuwe DuckDuckGo-functies, oplossingen en beveiligingsverbeteringen te blijven ontvangen.",
+          "primaryActionText": "macOS bijwerken"
+        },
+        "it": {
+          "titleText": "Il supporto per Big Sur è terminato",
+          "descriptionText": "Aggiorna macOS a Monterey o versioni successive per continuare a ricevere nuove funzionalità, correzioni e miglioramenti della sicurezza di DuckDuckGo.",
+          "primaryActionText": "Aggiorna macOS"
+        },
+        "es": {
+          "titleText": "El soporte para Big Sur ha finalizado",
+          "descriptionText": "Actualiza macOS a Monterey o una versión posterior para seguir recibiendo nuevas funciones, correcciones y mejoras de seguridad de DuckDuckGo.",
+          "primaryActionText": "Actualizar macOS"
+        },
+        "pl": {
+          "titleText": "Wsparcie dla Big Sur zostało zakończone",
+          "descriptionText": "Zaktualizuj macOS do wersji Monterey lub nowszej, aby nadal otrzymywać nowe funkcje, poprawki i ulepszenia zabezpieczeń DuckDuckGo.",
+          "primaryActionText": "Zaktualizuj macOS"
+        },
+        "ru": {
+          "titleText": "Поддержка Big Sur прекращена",
+          "descriptionText": "Обновите macOS до Monterey или более новой версии, чтобы продолжать получать новые функции, исправления и улучшения безопасности DuckDuckGo.",
+          "primaryActionText": "Обновить macOS"
+        },
+        "pt": {
+          "titleText": "O suporte ao Big Sur foi encerrado",
+          "descriptionText": "Atualize o macOS para o Monterey ou posterior para continuar recebendo novos recursos, correções e melhorias de segurança do DuckDuckGo.",
+          "primaryActionText": "Atualizar macOS"
         }
       },
       "matchingRules": [31]

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -482,7 +482,7 @@
         },
         "de": {
           "titleText": "Der Support für Big Sur ist eingestellt",
-          "descriptionText": "Aktualisiere macOS auf Monterey oder neuer, um weiterhin neue DuckDuckGo-Funktionen, Fehlerbehebungen und Sicherheitsverbesserungen zu erhalten.",
+          "descriptionText": "Aktualisieren Sie macOS auf Monterey oder neuer, um weiterhin neue DuckDuckGo-Funktionen, Fehlerbehebungen und Sicherheitsverbesserungen zu erhalten.",
           "primaryActionText": "macOS aktualisieren"
         },
         "nl": {
@@ -512,7 +512,7 @@
         },
         "pt": {
           "titleText": "O suporte ao Big Sur foi encerrado",
-          "descriptionText": "Atualize o macOS para o Monterey ou posterior para continuar recebendo novos recursos, correções e melhorias de segurança do DuckDuckGo.",
+          "descriptionText": "Atualiza o macOS para o Monterey ou posterior para continuares a receber novas funcionalidades, correções e melhorias de segurança do DuckDuckGo.",
           "primaryActionText": "Atualizar macOS"
         }
       },
@@ -533,11 +533,11 @@
         },
         "de": {
           "titleText": "Der Support für Big Sur ist eingestellt",
-          "descriptionText": "Die DuckDuckGo-Updates für macOS Big Sur wurden eingestellt. Dein Browser funktioniert weiterhin wie bisher."
+          "descriptionText": "Die DuckDuckGo-Updates für macOS Big Sur wurden eingestellt. Ihr Browser funktioniert weiterhin wie bisher."
         },
         "nl": {
           "titleText": "De ondersteuning voor Big Sur is beëindigd",
-          "descriptionText": "De DuckDuckGo-updates voor macOS Big Sur zijn beëindigd. Je browser blijft werken zoals nu."
+          "descriptionText": "De DuckDuckGo-updates voor macOS Big Sur zijn beëindigd. Uw browser blijft werken zoals nu."
         },
         "it": {
           "titleText": "Il supporto per Big Sur è terminato",
@@ -557,7 +557,7 @@
         },
         "pt": {
           "titleText": "O suporte ao Big Sur foi encerrado",
-          "descriptionText": "As atualizações do DuckDuckGo para o macOS Big Sur foram encerradas. Seu navegador continuará funcionando como hoje."
+          "descriptionText": "As atualizações do DuckDuckGo para o macOS Big Sur foram encerradas. O teu navegador continuará a funcionar como hoje."
         }
       },
       "matchingRules": [30]
@@ -583,7 +583,7 @@
         },
         "de": {
           "titleText": "Der Support für Big Sur ist eingestellt",
-          "descriptionText": "Aktualisiere macOS auf Monterey oder neuer, um weiterhin neue DuckDuckGo-Funktionen, Fehlerbehebungen und Sicherheitsverbesserungen zu erhalten.",
+          "descriptionText": "Aktualisieren Sie macOS auf Monterey oder neuer, um weiterhin neue DuckDuckGo-Funktionen, Fehlerbehebungen und Sicherheitsverbesserungen zu erhalten.",
           "primaryActionText": "macOS aktualisieren"
         },
         "nl": {
@@ -613,7 +613,7 @@
         },
         "pt": {
           "titleText": "O suporte ao Big Sur foi encerrado",
-          "descriptionText": "Atualize o macOS para o Monterey ou posterior para continuar recebendo novos recursos, correções e melhorias de segurança do DuckDuckGo.",
+          "descriptionText": "Atualiza o macOS para o Monterey ou posterior para continuares a receber novas funcionalidades, correções e melhorias de segurança do DuckDuckGo.",
           "primaryActionText": "Atualizar macOS"
         }
       },

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -543,6 +543,21 @@
         "placeholder": "VeryCriticalUpdate"
       },
       "matchingRules": [30]
+    },
+    {
+      "id": "macos_big_sur_eos_update_cta_legacy",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Big Sur support has ended",
+        "descriptionText": "Update macOS to Monterey or later to keep getting new DuckDuckGo features, fixes, and security improvements.",
+        "placeholder": "VeryCriticalUpdate",
+        "primaryActionText": "Update macOS",
+        "primaryAction": {
+          "type": "navigation",
+          "value": "softwareUpdate"
+        }
+      },
+      "matchingRules": [31]
     }
   ],
   "rules": [
@@ -682,7 +697,7 @@
       "id": 12,
       "attributes": {
         "appVersion": {
-          "min": "9999.0.0"
+          "min": "1.121.0"
         },
         "daysSinceInstalled": {
           "min": 14,
@@ -1010,8 +1025,12 @@
     {
       "id": 29,
       "attributes": {
-        "isInternalUser": {
-          "value": true
+        "appVersion": {
+          "min": "1.193.0"
+        },
+        "osApi": {
+          "min": "11.0.0",
+          "max": "11.999.999"
         },
         "canUpgradeOS": {
           "value": true
@@ -1021,11 +1040,27 @@
     {
       "id": 30,
       "attributes": {
-        "isInternalUser": {
-          "value": true
+        "appVersion": {
+          "min": "1.193.0"
+        },
+        "osApi": {
+          "min": "11.0.0",
+          "max": "11.999.999"
         },
         "canUpgradeOS": {
           "value": false
+        }
+      }
+    },
+    {
+      "id": 31,
+      "attributes": {
+        "appVersion": {
+          "max": "1.192.999"
+        },
+        "osApi": {
+          "min": "11.0.0",
+          "max": "11.999.999"
         }
       }
     }

--- a/schemas/macos/schema.json
+++ b/schemas/macos/schema.json
@@ -259,6 +259,7 @@
             "interactedWithMessage": { "$ref": "#/definitions/SingleValueStringArrayAttribute" },
             "interactedWithDeprecatedMacRemoteMessage": { "$ref": "#/definitions/SingleValueStringArrayAttribute" },
             "installedMacAppStore": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
+            "canUpgradeOS": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
             "pinnedTabs": { "$ref": "#/definitions/NumericRangeAttribute" },
             "customHomePage": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
             "duckPlayerOnboarded": { "$ref": "#/definitions/SingleValueBooleanAttribute" },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215118634345542?focus=true

Targets macOS Big Sur users with an end-of-support remote message, now that DuckDuckGo has dropped support for that OS version. The goal is to let Big Sur users know updates have ended and steer those who can to a newer macOS.

On clients that can [detect whether the hardware can move to a newer macOS](https://github.com/duckduckgo/apple-browsers/pull/5066), users who can upgrade see a message with an "Update macOS" call to action, while users who cannot get an informational notice that their browser keeps working as-is. Clients too old to detect upgrade capability fall back to showing the upgrade call to action to all Big Sur users.

All variants are scoped to Big Sur only and are now enabled for everyone (internal-only gating has been removed). The existing permanent survey is unaffected.

Steps to test this PR:
1. Install a 1.193.0 build on a Big Sur (macOS 11) Mac.
2. Point the build at this config.
3. Launch the app and confirm you see messaging indicating Big Sur is no longer supported.
4. Install the same build on a Mac running Monterey or later (macOS 12+).
5. Point the build at this config.
6. Launch the app and confirm no Big Sur message appears.

Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199177992965185)
[Technical Design Template](https://app.asana.com/0/59792373528535/184798220952357)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to remote config JSON and schema validation; impact is which in-app messages Big Sur users see, with no auth or data-path changes.
> 
> **Overview**
> Bumps macOS remote messaging config to **version 55** and adds **Big Sur end-of-support** messaging now that DuckDuckGo no longer updates on macOS 11. The generic **`macos_very_critical_update`** message (and its matching rule) is **removed** in favor of three targeted variants, each scoped to Big Sur via new rules **29–31** (`osApi` 11.x, app version gates).
> 
> Clients on **1.193.0+** that report **`canUpgradeOS`** see either an **“Update macOS”** CTA (`macos_big_sur_eos_update_cta` when upgrade is possible) or an informational **medium** message with no CTA (`macos_big_sur_eos_no_cta` when upgrade is not possible). Older clients (**≤1.192.999**) get a legacy upgrade CTA for all Big Sur users (`macos_big_sur_eos_update_cta_legacy`). All variants include the usual locale translations.
> 
> The macOS JSON schema now allows the **`canUpgradeOS`** boolean on matching rules. Existing app-update rules are renumbered (**27/28**) and **`installedMacAppStore`** is set explicitly on rule 28 for non–App Store installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbf90e446f7c731878393866afeac082ca1823d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->