### PR TITLE
[Windows] Update percentile of 14 day survey

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 57,
+  "version": 58,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -167,7 +167,7 @@
     {
       "id": 10,
       "targetPercentile": {
-        "before": 0.75
+        "before": 0.50
       },
       "attributes": {
         "daysSinceInstalled": {


### PR DESCRIPTION
This PR modifies the percentile of the 14 day survey message to now appear for 50% of users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote messaging config only; no app logic, auth, or data handling changes.
> 
> **Overview**
> Bumps **Windows** remote config to **version 58** and narrows who sees the **14-day “Help Us Improve”** survey (`windows_14_day_survey`).
> 
> For matching **rule 10**, `targetPercentile.before` changes from **0.75** to **0.50**, so eligible users in the 14–21 days-since-install window are now capped at **50%** exposure instead of **75%**. Install-day bounds, locale, and app version gates are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ffd4d276d6695ebbf83a00cc7d4ebd0002f95d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->