### PR TITLE
Delay iOS PIR freemium entry point RMF by 5 days after install

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 108,
+  "version": 109,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1055,6 +1055,9 @@
         },
         "freemiumPIRDidActivate": {
           "value": false
+        },
+        "daysSinceInstalled": {
+          "min": 5
         }
       }
     },


### PR DESCRIPTION
Asana task: https://app.asana.com/1/137249556945/project/72649045549333/task/1214893957137406

## Summary

Adds `daysSinceInstalled: { "min": 5 }` to rule `20` — the matcher backing the `ios_pir_freemium_entry_point` message.

## Why

Currently the PIR Freemium entry-point promo is shown immediately to eligible users, which competes with onboarding for new users and likely lowers engagement. Delaying by 5 days after install gives onboarding time to complete. Existing users are already past day 5 when this ships, so they remain immediately eligible.

## Change

```json
"daysSinceInstalled": {
  "min": 5
}
```

Added to rule 20 only. Rules 21 / 22 (post-scan results / no-results messages) are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e2aaf451845ec8056bf3b2c1cfe5a63559f1821e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->