### PR TITLE
Android: Update date to July for deprecation urgent notice

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,12 +1,12 @@
 {
-  "version": 104,
+  "version": 105,
   "messages": [
     {
       "id": "android_deprecation_urgent_notice_os8",
       "content": {
         "messageType": "medium",
         "titleText": "Important reminder: Upgrade to Android 9 or higher to stay protected",
-        "descriptionText": "After June 9, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
+        "descriptionText": "After July 9, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
         "placeholder": "CriticalUpdate"
       },
       "matchingRules": [25]
@@ -16,7 +16,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Important reminder: Upgrade to Android 9 or request subscription refund",
-        "descriptionText": "After June 9, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
+        "descriptionText": "After July 9, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
         "placeholder": "CriticalUpdate",
         "primaryActionText": "Request Subscription Refund",
         "primaryAction": {


### PR DESCRIPTION
**Asana:** https://app.asana.com/1/137249556945/task/1214637573512119?focus=true
**RMF task:** https://app.asana.com/1/137249556945/project/1207619243206445/task/1213465361640432?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and config version bump only; no logic, targeting, or security changes.
> 
> **Overview**
> Bumps **`live/android-config/android-config.json`** from version **104** to **105** and updates the Android 8/8.1 end-of-support date shown in two urgent deprecation in-app messages from **June 9, 2026** to **July 9, 2026**.
> 
> The same copy change applies to **`android_deprecation_urgent_notice_os8`** (standard users) and **`android_deprecation_urgent_notice_os8_ppro`** (Privacy Pro subscribers with refund CTA). Titles, matching rules, and actions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a64c0d672be928d57b0294bd31f52d4b7c9d3750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->