### PR TITLE
windows promote open at startup message

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 58,
+  "version": 59,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -74,6 +74,26 @@
         11,
         14
       ]
+    },
+    {
+      "id": "windows_promote_open_on_startup",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "Open DuckDuckGo when your computer starts up",
+        "descriptionText": "Get easy access to the DuckDuckGo browser when you start up your computer. ",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Enable in Settings",
+        "primaryAction": {
+          "type": "url",
+          "value": "duck://settings/general"
+        },
+        "secondaryActionText": "Not Now",
+        "secondaryAction": {
+          "type": "dismiss"
+        }
+      },
+      "matchingRules": [ 15 ],
+      "exclusionRules": []
     }
   ],
   "rules": [
@@ -202,6 +222,25 @@
       "attributes": {
         "interactedWithMessage": {
           "value": [ "windows_onboarding_v4_survey" ]
+        }
+      }
+    },
+    {
+      "id": 15,
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        },
+        "appVersion": {
+          "min": "0.142.10"
+        },
+        "atb": {
+          "max": "v513-6"
         }
       }
     }


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1207619243206445/task/1213098739658570

Added message to promote the 'open at startup' feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to messaging rules and copy; no application logic in this PR.
> 
> **Overview**
> Bumps **Windows remote config** to version **59** and adds an in-app promo for **open at startup**.
> 
> The new message `windows_promote_open_on_startup` uses a **big two-action** layout: **Enable in Settings** deep-links to `duck://settings/general`, and **Not Now** dismisses. It is gated by new rule **15** (English `en-US` / `en-CA` / `en-GB` / `en-AU`, app **≥ 0.142.10**, and `atb` **≤ v513-6**), with no exclusion rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0a59d4a4dcb011b1665ec7d891b15c355d77001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->