### PR TITLE
Windows Preview promotion messages

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 59,
+  "version": 60,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -94,6 +94,38 @@
       },
       "matchingRules": [ 15 ],
       "exclusionRules": []
+    },
+    {
+      "id": "windows_stable_previewpromo_2026",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Be the first to try our newest features!",
+        "descriptionText": "Get DuckDuckGo Preview for Windows, and try the latest features before anyone else.",
+        "placeholder": "Preview",
+        "primaryActionText": "Get Early Access",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/windows-preview"
+        }
+      },
+      "matchingRules": [ 16 ],
+      "exclusionRules": []
+    },
+    {
+      "id": "windows_preview_syncpromo_2026",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Set up Sync on DuckDuckGo Preview",
+        "descriptionText": "Using a previous version of our browser on Windows? Sync your passwords & bookmarks.",
+        "placeholder": "Preview",
+        "primaryActionText": "Set Up Sync",
+        "primaryAction": {
+          "type": "url",
+          "value": "duck://settings/sync"
+        }
+      },
+      "matchingRules": [ 17 ],
+      "exclusionRules": []
     }
   ],
   "rules": [
@@ -241,6 +273,45 @@
         },
         "atb": {
           "max": "v513-6"
+        }
+      }
+    },
+    {
+      "id": 16,
+      "targetPercentile": {
+        "before": 0.80
+      },
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB"
+          ]
+        },
+        "flavor": {
+          "value": "stable"
+        },
+        "defaultBrowser": {
+          "value": true
+        }
+      }
+    },
+    {
+      "id": 17,
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB"
+          ]
+        },
+        "flavor": {
+          "value": "preview"
+        },
+        "sync": {
+          "value": false
         }
       }
     }


### PR DESCRIPTION
See - 
https://app.asana.com/1/137249556945/project/1207619243206445/task/1213995540482538
https://app.asana.com/1/137249556945/project/1207619243206445/task/1213995540482530

A pair of messages to promote preview. The first shows for 20% of stable users a link to install preview. The second shows for preview users a link to enable the sync feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only messaging and targeting rules with no application logic changes; main risk is incorrect audience or URL targeting in production.
> 
> **Overview**
> Bumps **windows-config** from version **59** to **60** and adds two in-app **big_single_action** promos for the Windows Preview campaign.
> 
> **Stable → Preview:** `windows_stable_previewpromo_2026` targets English (US/CA/GB) **stable** users who are the **default browser**, with a percentile cap (`targetPercentile.before: 0.80`) for a limited rollout. Primary action opens `https://duckduckgo.com/windows-preview`.
> 
> **Preview → Sync:** `windows_preview_syncpromo_2026` targets the same locales on **preview** when **sync is off**, prompting setup via `duck://settings/sync`.
> 
> New matching rules **16** and **17** wire each message to those audiences; neither message defines exclusion rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1419e0edb588008f9d81bfbe8a8a8c8f243245af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->