### PR TITLE
fixed matching attributes for windows preview promotions

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 60,
+  "version": 61,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -290,7 +290,7 @@
           ]
         },
         "flavor": {
-          "value": "stable"
+          "value": [ "stable" ]
         },
         "defaultBrowser": {
           "value": true
@@ -308,7 +308,7 @@
           ]
         },
         "flavor": {
-          "value": "preview"
+          "value": [ "preview" ]
         },
         "sync": {
           "value": false


### PR DESCRIPTION
see https://github.com/duckduckgo/remote-messaging-config/pull/368 - but the matching attribute values are now correct

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only JSON shape fix for two promotion rules; no application code changes, but incorrect prior values may have blocked or mis-targeted those messages until clients pick up v61.
> 
> **Overview**
> Fixes **Windows preview promotion** targeting by correcting how `flavor` is specified on matching rules **16** and **17**, and bumps config **version** to **61**.
> 
> For the stable Preview promo (`windows_stable_previewpromo_2026`), `flavor` changes from the string `"stable"` to `[ "stable" ]`. For the Preview Sync promo (`windows_preview_syncpromo_2026`), `flavor` changes from `"preview"` to `[ "preview" ]`, consistent with other list-style attribute values (e.g. `locale`) so the remote messaging matcher can evaluate flavor correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 798072ffde1b5ba7e8ba61449911c5af7f2b10a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->