### PR TITLE
remove promote open at startup message

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 61,
+  "version": 62,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -74,26 +74,6 @@
         11,
         14
       ]
-    },
-    {
-      "id": "windows_promote_open_on_startup",
-      "content": {
-        "messageType": "big_two_action",
-        "titleText": "Open DuckDuckGo when your computer starts up",
-        "descriptionText": "Get easy access to the DuckDuckGo browser when you start up your computer. ",
-        "placeholder": "DDGAnnounce",
-        "primaryActionText": "Enable in Settings",
-        "primaryAction": {
-          "type": "url",
-          "value": "duck://settings/general"
-        },
-        "secondaryActionText": "Not Now",
-        "secondaryAction": {
-          "type": "dismiss"
-        }
-      },
-      "matchingRules": [ 15 ],
-      "exclusionRules": []
     },
     {
       "id": "windows_stable_previewpromo_2026",
@@ -254,25 +234,6 @@
       "attributes": {
         "interactedWithMessage": {
           "value": [ "windows_onboarding_v4_survey" ]
-        }
-      }
-    },
-    {
-      "id": 15,
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
-          ]
-        },
-        "appVersion": {
-          "min": "0.142.10"
-        },
-        "atb": {
-          "max": "v513-6"
         }
       }
     },


### PR DESCRIPTION
This removes the `windows_promote_open_on_startup` message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only removal of a promotional message with no auth, data, or app logic changes.
> 
> **Overview**
> Removes the **`windows_promote_open_on_startup`** in-app message that prompted users to enable opening DuckDuckGo at startup (Settings via `duck://settings/general`).
> 
> Also deletes **matching rule 15**, which gated that message (English locales, app ≥ 0.142.10, ATB ≤ v513-6), and bumps **`windows-config.json`** version **61 → 62**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0570899627987ae52524ac015b2f960ac164a00d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->