### PR TITLE
Retarget Windows preview promo to 40% of non-default stable users

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 62,
+  "version": 63,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -76,7 +76,7 @@
       ]
     },
     {
-      "id": "windows_stable_previewpromo_2026",
+      "id": "windows_stable_previewpromo_2026_2",
       "content": {
         "messageType": "big_single_action",
         "titleText": "Be the first to try our newest features!",
@@ -240,7 +240,7 @@
     {
       "id": 16,
       "targetPercentile": {
-        "before": 0.80
+        "before": 0.40
       },
       "attributes": {
         "locale": {
@@ -254,7 +254,7 @@
           "value": [ "stable" ]
         },
         "defaultBrowser": {
-          "value": true
+          "value": false
         }
       }
     },


### PR DESCRIPTION
Asana: [RMF: retarget Windows Preview promo to 40% of non-default stable users](https://app.asana.com/1/137249556945/task/1216070506275955)

## What

Renames the Windows stable→Preview promo message `windows_stable_previewpromo_2026` → `windows_stable_previewpromo_2026_2` (content unchanged) and updates its matching rule (`16`):

| | before #348 | after #372 (this PR!) |
|---|---|---|
| `targetPercentile.before` | `0.80` | **`0.40`** |
| `defaultBrowser` | `true` | **`false`** |

- `locale` (en-US / en-CA / en-GB) and `flavor: stable` are unchanged. 
- `windows-config` version bumped **62 → 63**. 
- The `windows_preview_syncpromo_2026` sync promo is untouched.

## Why

- The original RMD (#368) shipped to **80% of default-browser users** (accidentally; intended 20%) but Windows Preview DAU barely moved.
- The team [agreed](https://app.asana.com/1/137249556945/task/1215906794323811/comment/1216031894796178?focus=true)(Adam / Trish / Anya) to open it to a fresh audience: 
  - 40% of stable en-US / en-CA / en-GB users 
  - who have **not** set DDG as default, i.e. excluding default-browser users who mostly already saw the promo.

From Anya: 
> since the message content is unchanged, we can simply update the ID of the current message from windows_stable_previewpromo_2026 to something new (maybe even just windows_stable_previewpromo_2026_2 ?) for clean performance tracking and update the associated rules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote messaging JSON only—audience and ID changes with no app logic or security impact.
> 
> **Overview**
> Retargets the Windows stable **Preview** remote message by renaming it to `windows_stable_previewpromo_2026_2` (same copy and URL) and tightening **matching rule 16**: rollout percentile **`0.80` → `0.40`** and **`defaultBrowser: true` → `false`**, so en-US / en-CA / en-GB stable users who have **not** set DDG as default get a fresh cohort for measurement. Config **version 62 → 63**; other messages and rules (including the Preview sync promo) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8197a323e1dc4b4ed3537b7dc97fb4c2cfaa6ace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->