### PR TITLE
[iOS, macOS] Adds YouTube ad blocking promos

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -728,6 +728,10 @@
         "tr": {
           "titleText": "YouTube'u reklamsız izle!",
           "descriptionText": "Tarayıcımız artık YouTube videolarındaki reklamları engelliyor, böylece kesintisiz izleyebilirsin."
+        },
+        "jp": {
+          "titleText": "広告なしでYouTubeを見ましょう！",
+          "descriptionText": "DuckDuckGoブラウザではYouTube広告がブロックされるため、中断されずに動画を視聴できます。"
         }
       },
       "matchingRules": [
@@ -842,6 +846,10 @@
         "tr": {
           "titleText": "YouTube'daki reklamları engelle!",
           "descriptionText": "Tarayıcımız artık doğrudan YouTube'daki reklamları engelliyor, ayrıca Duck Player'ı hâlâ özel bir sinema modu olarak kullanabiliyorsun."
+        },
+        "jp": {
+          "titleText": "YouTubeで広告をブロック！",
+          "descriptionText": "DuckDuckGoブラウザで、YouTube広告を直接ブロックできるようになりました。しかも、Duck Playerはプライベートシアターモードで引き続き利用可能です。"
         }
       },
       "matchingRules": [
@@ -1361,6 +1369,7 @@
             "sk-SK",
             "sl-SI",
             "tr-TR",
+            "ja-JP",
             "en-FR",
             "en-DE",
             "en-NL",
@@ -1402,6 +1411,9 @@
         "duckPlayerEnabled": {
           "value": true
         },
+        "appVersion": {
+          "min": "7.225.0"
+        },
         "interactedWithMessage": {
           "value": [
             "funnel_newtab_adblockermf_ios2"
@@ -1414,6 +1426,9 @@
       "attributes": {
         "duckPlayerEnabled": {
           "value": false
+        },
+        "appVersion": {
+          "min": "7.225.0"
         },
         "interactedWithMessage": {
           "value": [

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 110,
+  "version": 111,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",
@@ -622,6 +622,234 @@
         23
       ],
       "exclusionRules": []
+    },
+    {
+      "id": "funnel_newtab_adblockermf_ios1",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Watch YouTube without ads!",
+        "descriptionText": "Our browser now blocks ads on YouTube videos, so you can watch without interruption.",
+        "placeholder": "Announce",
+        "imageUrl":  "https://staticcdn.duckduckgo.com/remotemessaging/illustrations/youtube_new.png"
+      },
+      "translations": {
+        "fr": {
+          "titleText": "Regardez YouTube sans publicités !",
+          "descriptionText": "Notre navigateur bloque désormais les publicités sur YouTube, pour des vidéos sans interruption."
+        },
+        "de": {
+          "titleText": "YouTube ohne Werbung ansehen!",
+          "descriptionText": "Unser Browser blockiert jetzt Werbung in YouTube-Videos, sodass du ohne Unterbrechung schauen kannst."
+        },
+        "nl": {
+          "titleText": "Bekijk YouTube zonder advertenties!",
+          "descriptionText": "Onze browser blokkeert nu advertenties bij YouTube-video's, zodat je ongestoord kunt kijken."
+        },
+        "it": {
+          "titleText": "Guarda YouTube senza annunci!",
+          "descriptionText": "Ora il nostro browser blocca gli annunci nei video di YouTube, così puoi guardarli senza interruzioni."
+        },
+        "es": {
+          "titleText": "¡Mira YouTube sin anuncios!",
+          "descriptionText": "Nuestro navegador ahora bloquea los anuncios en vídeos de YouTube, para que puedas verlos sin interrupciones."
+        },
+        "pl": {
+          "titleText": "Oglądaj YouTube bez reklam!",
+          "descriptionText": "Nasza przeglądarka blokuje teraz reklamy na filmach YouTube, dzięki czemu możesz oglądać bez przerwy."
+        },
+        "pt": {
+          "titleText": "Vê o YouTube sem anúncios!",
+          "descriptionText": "Agora, o nosso navegador bloqueia anúncios nos vídeos do YouTube para que possas assistir sem interrupções."
+        },
+        "ru": {
+          "titleText": "Смотрите YouTube без рекламы!",
+          "descriptionText": "Наш браузер теперь блокирует рекламу на YouTube, так что вы можете смотреть без перерывов."
+        },
+        "sv": {
+          "titleText": "Titta på YouTube utan annonser!",
+          "descriptionText": "Vår webbläsare blockerar nu annonser på YouTube-videor, så att du kan titta utan avbrott."
+        },
+        "bg": {
+          "titleText": "Гледайте YouTube без реклами!",
+          "descriptionText": "Нашият браузър вече блокира реклами във видеоклипове в YouTube, за да можете да гледате без прекъсване."
+        },
+        "hr": {
+          "titleText": "Gledaj YouTube bez oglasa!",
+          "descriptionText": "Naš preglednik sada blokira oglase na YouTube videozapisima, tako da ih možeš gledati bez prekida."
+        },
+        "cs": {
+          "titleText": "Sleduj YouTube bez reklam!",
+          "descriptionText": "Náš prohlížeč teď blokuje reklamy ve videích na YouTube, takže je můžeš sledovat bez přerušení."
+        },
+        "da": {
+          "titleText": "Se YouTube uden annoncer!",
+          "descriptionText": "Vores browser blokerer nu annoncer på YouTube-videoer, så du kan se uden afbrydelser."
+        },
+        "et": {
+          "titleText": "Vaata YouTube'i ilma reklaamideta!",
+          "descriptionText": "Meie brauser blokeerib nüüd YouTube'i videotes reklaame, nii et saad neid katkestuseta vaadata."
+        },
+        "fi": {
+          "titleText": "Katso YouTubea ilman mainoksia!",
+          "descriptionText": "Selaimemme estää nyt mainokset YouTube-videoissa, joten voit katsoa niitä keskeytyksettä."
+        },
+        "el": {
+          "titleText": "Παρακολουθήστε στο YouTube χωρίς διαφημίσεις!",
+          "descriptionText": "Το πρόγραμμα περιήγησής μας πλέον αποκλείει τις διαφημίσεις στα βίντεο του YouTube, ώστε να μπορείτε να τα παρακολουθείτε χωρίς διακοπές."
+        },
+        "hu": {
+          "titleText": "Nézz YouTube-videókat hirdetések nélkül!",
+          "descriptionText": "Böngészőnk mostantól blokkolja a hirdetéseket a YouTube-videókban, így megszakítás nélkül nézheted őket."
+        },
+        "lv": {
+          "titleText": "Skaties YouTube bez reklāmām!",
+          "descriptionText": "Mūsu pārlūks tagad bloķē reklāmas YouTube videoklipos, lai tu varētu skatīties bez pārtraukumiem."
+        },
+        "lt": {
+          "titleText": "Žiūrėkite „YouTube\" be reklamos!",
+          "descriptionText": "Mūsų naršyklė dabar blokuoja reklamą „YouTube\" vaizdo įrašuose, todėl galite žiūrėti be pertraukimų."
+        },
+        "nb": {
+          "titleText": "Se YouTube uten annonser!",
+          "descriptionText": "Nettleseren vår blokkerer nå annonser på YouTube-videoer, slik at du kan se dem uten avbrudd."
+        },
+        "ro": {
+          "titleText": "Urmărește YouTube fără reclame!",
+          "descriptionText": "Browserul nostru blochează acum reclamele din videoclipurile de pe YouTube, astfel încât să le poți viziona fără întreruperi."
+        },
+        "sk": {
+          "titleText": "Sleduj YouTube bez reklám!",
+          "descriptionText": "Náš prehliadač teraz blokuje reklamy vo videách na YouTube, takže ich môžeš sledovať bez prerušenia."
+        },
+        "sl": {
+          "titleText": "Glejte YouTube brez oglasov!",
+          "descriptionText": "Naš brskalnik zdaj blokira oglase v videoposnetkih na YouTubu, tako da si jih lahko ogledate brez prekinitev."
+        },
+        "tr": {
+          "titleText": "YouTube'u reklamsız izle!",
+          "descriptionText": "Tarayıcımız artık YouTube videolarındaki reklamları engelliyor, böylece kesintisiz izleyebilirsin."
+        }
+      },
+      "matchingRules": [
+        24
+      ],
+      "exclusionRules": [
+        25
+      ]
+    },
+    {
+      "id": "funnel_newtab_adblockermf_ios2",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Block ads on YouTube!",
+        "descriptionText": "Our browser now blocks ads directly on YouTube, plus you can still use Duck Player as a private theater mode.",
+        "placeholder": "Announce",
+        "imageUrl":  "https://staticcdn.duckduckgo.com/remotemessaging/illustrations/youtube_new.png"
+      },
+      "translations": {
+        "fr": {
+          "titleText": "Bloquez les publicités sur YouTube !",
+          "descriptionText": "Notre navigateur bloque désormais les publicités directement sur YouTube. Duck Player reste disponible si vous avez besoin d'un mode « salle de projection privée »."
+        },
+        "de": {
+          "titleText": "Werbung auf YouTube blockieren!",
+          "descriptionText": "Unser Browser blockiert ab sofort Werbung direkt auf YouTube, außerdem kannst du Duck Player weiterhin als privaten Theatermodus nutzen."
+        },
+        "nl": {
+          "titleText": "Blokkeer advertenties op YouTube!",
+          "descriptionText": "Onze browser blokkeert advertenties nu direct op YouTube, en je kunt Duck Player nog steeds gebruiken als theater modus."
+        },
+        "it": {
+          "titleText": "Blocca gli annunci su YouTube!",
+          "descriptionText": "Ora il nostro browser blocca gli annunci direttamente su YouTube e puoi ancora utilizzare Duck Player come modalità cinema privata."
+        },
+        "es": {
+          "titleText": "¡Bloquea anuncios en YouTube!",
+          "descriptionText": "Nuestro navegador ahora bloquea los anuncios directamente en YouTube; además, puedes seguir usando Duck Player en modo cine."
+        },
+        "pl": {
+          "titleText": "Blokuj reklamy na YouTube!",
+          "descriptionText": "Nasza przeglądarka blokuje teraz reklamy bezpośrednio na YouTube, a ponadto nadal możesz używać Duck Playera w prywatnym trybie kina."
+        },
+        "pt": {
+          "titleText": "Bloqueia anúncios no YouTube!",
+          "descriptionText": "O nosso navegador agora bloqueia anúncios diretamente no YouTube, além disso, ainda podes usar o Duck Player como modo de teatro privado."
+        },
+        "ru": {
+          "titleText": "Блокировка рекламы на YouTube",
+          "descriptionText": "Наш браузер теперь блокирует рекламу прямо на YouTube, плюс вы по-прежнему можете использовать Duck Player для режима частного кинотеатра."
+        },
+        "sv": {
+          "titleText": "Blockera annonser på YouTube!",
+          "descriptionText": "Vår webbläsare blockerar nu annonser direkt på YouTube, och du kan fortfarande använda Duck Player som ett privat bioläge."
+        },
+        "bg": {
+          "titleText": "Блокирайте рекламите в YouTube!",
+          "descriptionText": "Нашият браузър вече блокира рекламите директно в YouTube, а освен това все още можете да използвате Duck Player в режим на частно кино."
+        },
+        "hr": {
+          "titleText": "Blokiraj oglase na YouTubeu!",
+          "descriptionText": "Naš preglednik sada blokira oglase izravno na YouTubeu, a Duck Player i dalje možeš koristiti kao način rada privatnog kina."
+        },
+        "cs": {
+          "titleText": "Blokuj reklamy na YouTube!",
+          "descriptionText": "Náš prohlížeč teď blokuje reklamy přímo na YouTube a navíc můžeš stále používat Duck Player jako režim soukromého kina."
+        },
+        "da": {
+          "titleText": "Bloker annoncer på YouTube!",
+          "descriptionText": "Vores browser blokerer nu annoncer direkte på YouTube, og du kan stadig bruge Duck Player som en privat biograftilstand."
+        },
+        "et": {
+          "titleText": "Blokeeri reklaamid YouTube'is!",
+          "descriptionText": "Meie brauser blokeerib nüüd YouTube'is otse reklaame ja lisaks saad Duck Playerit endiselt privaatse kinorežiimina kasutada."
+        },
+        "fi": {
+          "titleText": "Estä mainokset YouTubessa!",
+          "descriptionText": "Selaimemme estää nyt mainokset suoraan YouTubessa, ja voit edelleen käyttää Duck Playeria yksityisenä teatteritilana."
+        },
+        "el": {
+          "titleText": "Αποκλείστε διαφημίσεις στο YouTube!",
+          "descriptionText": "Το πρόγραμμα περιήγησής μας πλέον αποκλείει τις διαφημίσεις απευθείας στο YouTube, ενώ παράλληλα μπορείτε να χρησιμοποιήσετε το Duck Player ως λειτουργία ιδιωτικού κινηματογράφου."
+        },
+        "hu": {
+          "titleText": "Blokkold a hirdetéseket a YouTube-on!",
+          "descriptionText": "Böngészőnk mostantól közvetlenül a YouTube-on blokkolja a hirdetéseket, és továbbra is használhatod a Duck Playert privát mozimódként."
+        },
+        "lv": {
+          "titleText": "Bloķē YouTube reklāmas!",
+          "descriptionText": "Mūsu pārlūks tagad bloķē reklāmas tieši pakalpojumā YouTube, un tu joprojām vari izmantot Duck Player kā privātu kinoteātra režīmu."
+        },
+        "lt": {
+          "titleText": "Blokuokite reklamą „YouTube\"!",
+          "descriptionText": "Mūsų naršyklė dabar blokuoja reklamą tiesiogiai platformoje „YouTube\", be to, vis tiek galite naudoti „Duck Player\" kaip privatų kino teatro režimą."
+        },
+        "nb": {
+          "titleText": "Blokker annonser på YouTube!",
+          "descriptionText": "Nettleseren vår blokkerer nå annonser direkte på YouTube, og du kan fortsatt bruke Duck Player som en privat kinomodus."
+        },
+        "ro": {
+          "titleText": "Blochează reclamele pe YouTube!",
+          "descriptionText": "Browserul nostru blochează acum direct reclamele pe YouTube și, în plus, poți folosi în continuare Duck Player ca mod de cinema privat."
+        },
+        "sk": {
+          "titleText": "Blokuj reklamy na YouTube!",
+          "descriptionText": "Náš prehliadač teraz blokuje reklamy priamo na YouTube a navyše môžeš stále používať Duck Player ako režim súkromného kina."
+        },
+        "sl": {
+          "titleText": "Blokirajte oglase na YouTube!",
+          "descriptionText": "Naš brskalnik zdaj blokira oglase neposredno na YouTubu, poleg tega pa lahko Duck Player še vedno uporabljate kot način zasebnega kina."
+        },
+        "tr": {
+          "titleText": "YouTube'daki reklamları engelle!",
+          "descriptionText": "Tarayıcımız artık doğrudan YouTube'daki reklamları engelliyor, ayrıca Duck Player'ı hâlâ özel bir sinema modu olarak kullanabiliyorsun."
+        }
+      },
+      "matchingRules": [
+        24
+      ],
+      "exclusionRules": [
+        26
+      ]
     }
   ],
   "rules": [
@@ -1091,6 +1319,106 @@
         },
         "daysSinceInstalled": {
           "min": 58
+        }
+      }
+    },
+    {
+      "id": 24,
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-GB",
+            "en-US",
+            "en-CA",
+            "fr-FR",
+            "fr-CA",
+            "fr-LU",
+            "fr-BE",
+            "de-DE",
+            "de-AT",
+            "de-LU",
+            "de-BE",
+            "nl-NL",
+            "nl-BE",
+            "it-IT",
+            "es-ES",
+            "pl-PL",
+            "pt-PT",
+            "ru-RU",
+            "sv-SE",
+            "bg-BG",
+            "hr-HR",
+            "cs-CZ",
+            "da-DK",
+            "et-EE",
+            "fi-FI",
+            "el-GR",
+            "hu-HU",
+            "lv-LV",
+            "lt-LT",
+            "nb-NO",
+            "ro-RO",
+            "sk-SK",
+            "sl-SI",
+            "tr-TR",
+            "en-FR",
+            "en-DE",
+            "en-NL",
+            "en-ES",
+            "en-BG",
+            "en-CZ",
+            "en-DK",
+            "en-GR",
+            "en-EE",
+            "en-FI",
+            "en-HR",
+            "en-IT",
+            "en-LT",
+            "en-LV",
+            "en-NO",
+            "en-PL",
+            "en-PT",
+            "en-RO",
+            "en-RU",
+            "en-SK",
+            "en-SI",
+            "en-SE",
+            "en-TR",
+            "en-JP",
+            "en-IE",
+            "en-MT",
+            "en-CY",
+            "en-LU",
+            "en-AT",
+            "en-BE",
+            "en-HU"
+          ]
+        }
+      }
+    },
+    {
+      "id": 25,
+      "attributes": {
+        "duckPlayerEnabled": {
+          "value": true
+        },
+        "interactedWithMessage": {
+          "value": [
+            "funnel_newtab_adblockermf_ios2"
+          ]
+        }
+      }
+    },
+    {
+      "id": 26,
+      "attributes": {
+        "duckPlayerEnabled": {
+          "value": false
+        },
+        "interactedWithMessage": {
+          "value": [
+            "funnel_newtab_adblockermf_ios1"
+          ]
         }
       }
     }

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -729,7 +729,7 @@
           "titleText": "YouTube'u reklamsız izle!",
           "descriptionText": "Tarayıcımız artık YouTube videolarındaki reklamları engelliyor, böylece kesintisiz izleyebilirsin."
         },
-        "jp": {
+        "ja": {
           "titleText": "広告なしでYouTubeを見ましょう！",
           "descriptionText": "DuckDuckGoブラウザではYouTube広告がブロックされるため、中断されずに動画を視聴できます。"
         }
@@ -738,7 +738,7 @@
         24
       ],
       "exclusionRules": [
-        25
+        26
       ]
     },
     {
@@ -847,16 +847,16 @@
           "titleText": "YouTube'daki reklamları engelle!",
           "descriptionText": "Tarayıcımız artık doğrudan YouTube'daki reklamları engelliyor, ayrıca Duck Player'ı hâlâ özel bir sinema modu olarak kullanabiliyorsun."
         },
-        "jp": {
+        "ja": {
           "titleText": "YouTubeで広告をブロック！",
           "descriptionText": "DuckDuckGoブラウザで、YouTube広告を直接ブロックできるようになりました。しかも、Duck Playerはプライベートシアターモードで引き続き利用可能です。"
         }
       },
       "matchingRules": [
-        24
+        25
       ],
       "exclusionRules": [
-        26
+        27
       ]
     }
   ],
@@ -1402,18 +1402,99 @@
             "en-BE",
             "en-HU"
           ]
+        },
+        "appVersion": {
+          "min": "7.225.0"
+        },
+        "duckPlayerEnabled": {
+          "value": false
         }
       }
     },
     {
       "id": 25,
       "attributes": {
-        "duckPlayerEnabled": {
-          "value": true
+        "locale": {
+          "value": [
+            "en-GB",
+            "en-US",
+            "en-CA",
+            "fr-FR",
+            "fr-CA",
+            "fr-LU",
+            "fr-BE",
+            "de-DE",
+            "de-AT",
+            "de-LU",
+            "de-BE",
+            "nl-NL",
+            "nl-BE",
+            "it-IT",
+            "es-ES",
+            "pl-PL",
+            "pt-PT",
+            "ru-RU",
+            "sv-SE",
+            "bg-BG",
+            "hr-HR",
+            "cs-CZ",
+            "da-DK",
+            "et-EE",
+            "fi-FI",
+            "el-GR",
+            "hu-HU",
+            "lv-LV",
+            "lt-LT",
+            "nb-NO",
+            "ro-RO",
+            "sk-SK",
+            "sl-SI",
+            "tr-TR",
+            "ja-JP",
+            "en-FR",
+            "en-DE",
+            "en-NL",
+            "en-ES",
+            "en-BG",
+            "en-CZ",
+            "en-DK",
+            "en-GR",
+            "en-EE",
+            "en-FI",
+            "en-HR",
+            "en-IT",
+            "en-LT",
+            "en-LV",
+            "en-NO",
+            "en-PL",
+            "en-PT",
+            "en-RO",
+            "en-RU",
+            "en-SK",
+            "en-SI",
+            "en-SE",
+            "en-TR",
+            "en-JP",
+            "en-IE",
+            "en-MT",
+            "en-CY",
+            "en-LU",
+            "en-AT",
+            "en-BE",
+            "en-HU"
+          ]
         },
         "appVersion": {
           "min": "7.225.0"
         },
+        "duckPlayerEnabled": {
+          "value": true
+        }
+      }
+    },
+    {
+      "id": 26,
+      "attributes": {
         "interactedWithMessage": {
           "value": [
             "funnel_newtab_adblockermf_ios2"
@@ -1422,14 +1503,8 @@
       }
     },
     {
-      "id": 26,
+      "id": 27,
       "attributes": {
-        "duckPlayerEnabled": {
-          "value": false
-        },
-        "appVersion": {
-          "min": "7.225.0"
-        },
         "interactedWithMessage": {
           "value": [
             "funnel_newtab_adblockermf_ios1"

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -618,6 +618,104 @@
         }
       },
       "matchingRules": [31]
+    },
+    {
+      "id": "funnel_newtab_adblockermf_mac1",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Watch YouTube without ads!",
+        "descriptionText": "Our browser now blocks ads on YouTube videos, so you can watch without interruption.",
+        "placeholder": "YoutubeNew"
+      },
+      "translations": {
+        "fr": {
+          "titleText": "Regardez YouTube sans publicités !",
+          "descriptionText": "Notre navigateur bloque désormais les publicités sur YouTube, pour des vidéos sans interruption."
+        },
+        "de": {
+          "titleText": "YouTube ohne Werbung ansehen!",
+          "descriptionText": "Unser Browser blockiert jetzt Werbung in YouTube-Videos, sodass du ohne Unterbrechung schauen kannst."
+        },
+        "nl": {
+          "titleText": "Bekijk YouTube zonder advertenties!",
+          "descriptionText": "Onze browser blokkeert nu advertenties bij YouTube-video's, zodat je ongestoord kunt kijken."
+        },
+        "it": {
+          "titleText": "Guarda YouTube senza annunci!",
+          "descriptionText": "Ora il nostro browser blocca gli annunci nei video di YouTube, così puoi guardarli senza interruzioni."
+        },
+        "es": {
+          "titleText": "¡Mira YouTube sin anuncios!",
+          "descriptionText": "Nuestro navegador ahora bloquea los anuncios en vídeos de YouTube, para que puedas verlos sin interrupciones."
+        },
+        "pl": {
+          "titleText": "Oglądaj YouTube bez reklam!",
+          "descriptionText": "Nasza przeglądarka blokuje teraz reklamy na filmach YouTube, dzięki czemu możesz oglądać bez przerwy."
+        },
+        "pt": {
+          "titleText": "Vê o YouTube sem anúncios!",
+          "descriptionText": "Agora, o nosso navegador bloqueia anúncios nos vídeos do YouTube para que possas assistir sem interrupções."
+        },
+        "ru": {
+          "titleText": "Смотрите YouTube без рекламы!",
+          "descriptionText": "Наш браузер теперь блокирует рекламу на YouTube, так что вы можете смотреть без перерывов."
+        }
+      },
+      "matchingRules": [
+        32
+      ],
+      "exclusionRules": [
+        33
+      ]
+    },
+    {
+      "id": "funnel_newtab_adblockermf_mac2",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Block ads on YouTube!",
+        "descriptionText": "Our browser now blocks ads directly on YouTube, plus you can still use Duck Player as a private theater mode.",
+        "placeholder": "YoutubeNew"
+      },
+      "translations": {
+        "fr": {
+          "titleText": "Bloquez les publicités sur YouTube !",
+          "descriptionText": "Notre navigateur bloque désormais les publicités directement sur YouTube. Duck Player reste disponible si vous avez besoin d'un mode « salle de projection privée »."
+        },
+        "de": {
+          "titleText": "Werbung auf YouTube blockieren!",
+          "descriptionText": "Unser Browser blockiert ab sofort Werbung direkt auf YouTube, außerdem kannst du Duck Player weiterhin als privaten Theatermodus nutzen."
+        },
+        "nl": {
+          "titleText": "Blokkeer advertenties op YouTube!",
+          "descriptionText": "Onze browser blokkeert advertenties nu direct op YouTube, en je kunt Duck Player nog steeds gebruiken als theater modus."
+        },
+        "it": {
+          "titleText": "Blocca gli annunci su YouTube!",
+          "descriptionText": "Ora il nostro browser blocca gli annunci direttamente su YouTube e puoi ancora utilizzare Duck Player come modalità cinema privata."
+        },
+        "es": {
+          "titleText": "¡Bloquea anuncios en YouTube!",
+          "descriptionText": "Nuestro navegador ahora bloquea los anuncios directamente en YouTube; además, puedes seguir usando Duck Player en modo cine."
+        },
+        "pl": {
+          "titleText": "Blokuj reklamy na YouTube!",
+          "descriptionText": "Nasza przeglądarka blokuje teraz reklamy bezpośrednio na YouTube, a ponadto nadal możesz używać Duck Playera w prywatnym trybie kina."
+        },
+        "pt": {
+          "titleText": "Bloqueia anúncios no YouTube!",
+          "descriptionText": "O nosso navegador agora bloqueia anúncios diretamente no YouTube, além disso, ainda podes usar o Duck Player como modo de teatro privado."
+        },
+        "ru": {
+          "titleText": "Блокировка рекламы на YouTube",
+          "descriptionText": "Наш браузер теперь блокирует рекламу прямо на YouTube, плюс вы по-прежнему можете использовать Duck Player для режима частного кинотеатра."
+        }
+      },
+      "matchingRules": [
+        32
+      ],
+      "exclusionRules": [
+        34
+      ]
     }
   ],
   "rules": [
@@ -1110,6 +1208,73 @@
         "osApi": {
           "min": "11.0.0",
           "max": "11.999.999"
+        }
+      }
+    },
+    {
+      "id": 32,
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-GB",
+            "en-US",
+            "en-CA",
+            "fr-FR",
+            "fr-CA",
+            "fr-LU",
+            "fr-BE",
+            "de-DE",
+            "de-AT",
+            "de-LU",
+            "de-BE",
+            "nl-NL",
+            "nl-BE",
+            "it-IT",
+            "es-ES",
+            "pl-PL",
+            "pt-PT",
+            "ru-RU",
+            "en-FR",
+            "en-DE",
+            "en-NL",
+            "en-ES",
+            "en-IT",
+            "en-PL",
+            "en-PT",
+            "en-RU",
+            "en-IE",
+            "en-MT",
+            "en-CY",
+            "en-LU",
+            "en-AT",
+            "en-BE"
+          ]
+        }
+      }
+    },
+    {
+      "id": 33,
+      "attributes": {
+        "duckPlayerEnabled": {
+          "value": true
+        },
+        "interactedWithMessage": {
+          "value": [
+            "funnel_newtab_adblockermf_mac2"
+          ]
+        }
+      }
+    },
+    {
+      "id": 34,
+      "attributes": {
+        "duckPlayerEnabled": {
+          "value": false
+        },
+        "interactedWithMessage": {
+          "value": [
+            "funnel_newtab_adblockermf_mac1"
+          ]
         }
       }
     }

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -665,7 +665,7 @@
         32
       ],
       "exclusionRules": [
-        33
+        34
       ]
     },
     {
@@ -711,10 +711,10 @@
         }
       },
       "matchingRules": [
-        32
+        33
       ],
       "exclusionRules": [
-        34
+        35
       ]
     }
   ],
@@ -1249,18 +1249,65 @@
             "en-AT",
             "en-BE"
           ]
+        },
+        "appVersion": {
+          "min": "1.195.0"
+        },
+        "duckPlayerEnabled": {
+          "value": false
         }
       }
     },
     {
       "id": 33,
       "attributes": {
-        "duckPlayerEnabled": {
-          "value": true
+        "locale": {
+          "value": [
+            "en-GB",
+            "en-US",
+            "en-CA",
+            "fr-FR",
+            "fr-CA",
+            "fr-LU",
+            "fr-BE",
+            "de-DE",
+            "de-AT",
+            "de-LU",
+            "de-BE",
+            "nl-NL",
+            "nl-BE",
+            "it-IT",
+            "es-ES",
+            "pl-PL",
+            "pt-PT",
+            "ru-RU",
+            "en-FR",
+            "en-DE",
+            "en-NL",
+            "en-ES",
+            "en-IT",
+            "en-PL",
+            "en-PT",
+            "en-RU",
+            "en-IE",
+            "en-MT",
+            "en-CY",
+            "en-LU",
+            "en-AT",
+            "en-BE"
+          ]
         },
         "appVersion": {
           "min": "1.195.0"
         },
+        "duckPlayerEnabled": {
+          "value": true
+        }
+      }
+    },
+    {
+      "id": 34,
+      "attributes": {
         "interactedWithMessage": {
           "value": [
             "funnel_newtab_adblockermf_mac2"
@@ -1269,14 +1316,8 @@
       }
     },
     {
-      "id": 34,
+      "id": 35,
       "attributes": {
-        "duckPlayerEnabled": {
-          "value": false
-        },
-        "appVersion": {
-          "min": "1.195.0"
-        },
         "interactedWithMessage": {
           "value": [
             "funnel_newtab_adblockermf_mac1"

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1258,6 +1258,9 @@
         "duckPlayerEnabled": {
           "value": true
         },
+        "appVersion": {
+          "min": "1.195.0"
+        },
         "interactedWithMessage": {
           "value": [
             "funnel_newtab_adblockermf_mac2"
@@ -1270,6 +1273,9 @@
       "attributes": {
         "duckPlayerEnabled": {
           "value": false
+        },
+        "appVersion": {
+          "min": "1.195.0"
         },
         "interactedWithMessage": {
           "value": [

--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 55,
+  "version": 56,
   "messages": [
     {
       "id": "macos_privacy_pro_exit_survey_1",

--- a/schemas/ios/schema.json
+++ b/schemas/ios/schema.json
@@ -99,6 +99,10 @@
           "$ref": "#/definitions/PlaceholderType",
           "description": "Placeholder type for the message"
         },
+        "imageUrl": {
+          "type": "string",
+          "description": "Remote image URL for the message"
+        },
         "actionText": {
           "type": "string",
           "description": "Text for the action button (used in promo_single_action)"

--- a/schemas/macos/schema.json
+++ b/schemas/macos/schema.json
@@ -404,7 +404,8 @@
         "RadarCheckPurple",
         "PIR",
         "Subscription",
-        "VeryCriticalUpdate"
+        "VeryCriticalUpdate",
+        "YoutubeNew"
       ]
     },
     "SurfaceType": {


### PR DESCRIPTION
Message 1
iOS: https://app.asana.com/1/137249556945/project/72649045549333/task/1214903532002235?focus=true
macOS: https://app.asana.com/1/137249556945/project/72649045549333/task/1214903329769595?focus=true

Message 2
iOS: https://app.asana.com/1/137249556945/project/72649045549333/task/1214896260901212?focus=true
macOS: https://app.asana.com/1/137249556945/project/72649045549333/task/1214896260901210?focus=true

Description:
Add YouTube ad blocking promotions for iOS, macOS. First message targets users with `duckPlayerEnabled=false`, while second targets those with `duckPlayerEnabled=true`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote messaging JSON only; no application code changes. Main review focus is correct rule IDs, locales, and version gates before rollout.
> 
> **Overview**
> Adds **remote new-tab promos** for YouTube ad blocking on **iOS** (`ios-config.json` version **111**) and **macOS** (`macos-config.json`).
> 
> Each platform gets **two** `medium` messages with localized copy: a general **“watch without ads”** variant (`funnel_newtab_adblockermf_ios1` / `_mac1`) and a **Duck Player** variant that also mentions in-browser blocking (`…_ios2` / `…_mac2`). iOS includes broader locale translations and a shared illustration URL; macOS uses the `YoutubeNew` placeholder.
> 
> **Targeting** uses new rules: locale allowlists (rule **24** on iOS, **32** on macOS), plus exclusion rules that tie **minimum app versions** (iOS **7.225.0**, macOS **1.195.0**), **`duckPlayerEnabled`**, and **`interactedWithMessage`** so users aren’t shown the alternate variant after engaging with the other message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7018672316d462ad3fbe514bae36f7557964da2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->