### PR TITLE
Android: Adjust deprecation dates

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,12 +1,12 @@
 {
-  "version": 105,
+  "version": 106,
   "messages": [
     {
       "id": "android_deprecation_urgent_notice_os8",
       "content": {
         "messageType": "medium",
         "titleText": "Important reminder: Upgrade to Android 9 or higher to stay protected",
-        "descriptionText": "After July 9, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
+        "descriptionText": "After July 15, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
         "placeholder": "CriticalUpdate"
       },
       "matchingRules": [25]
@@ -16,7 +16,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Important reminder: Upgrade to Android 9 or request subscription refund",
-        "descriptionText": "After July 9, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
+        "descriptionText": "After July 15, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
         "placeholder": "CriticalUpdate",
         "primaryActionText": "Request Subscription Refund",
         "primaryAction": {


### PR DESCRIPTION
https://app.asana.com/1/137249556945/task/1216236174474890?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only remote config with a version bump; no app logic changes, though the date must stay aligned with the real support cutoff.
> 
> **Overview**
> Updates live Android remote messaging config so the **Android 8 / 8.1 support end date** shown to users moves from **July 9, 2026** to **July 15, 2026**.
> 
> Both urgent deprecation notices are updated: the standard `android_deprecation_urgent_notice_os8` message and the Privacy Pro variant `android_deprecation_urgent_notice_os8_ppro` (same body text; PPro keeps the subscription refund action). Config **`version`** is bumped **105 → 106** so clients pick up the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24a6a631e58966d2dff88e6e2d6826734831cca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->