### PR TITLE
added adblock messages for windows

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 63,
+  "version": 64,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -106,6 +106,152 @@
       },
       "matchingRules": [ 17 ],
       "exclusionRules": []
+    },
+    {
+      "id": "funnel_newtab_adblockermf_windows1",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Watch YouTube without ads!",
+        "descriptionText": "Our browser now blocks ads on YouTube videos, so you can watch without interruption.",
+        "placeholder": "YoutubeNew"
+      },
+      "translations": {
+        "fr-FR": {
+          "titleText": "Regardez YouTube sans publicités !",
+          "descriptionText": "Notre navigateur bloque désormais les publicités sur YouTube, pour des vidéos sans interruption."
+        },
+        "fr-CA": {
+          "titleText": "Regardez YouTube sans publicités !",
+          "descriptionText": "Notre navigateur bloque désormais les publicités sur YouTube, pour des vidéos sans interruption."
+        },
+        "fr-LU": {
+          "titleText": "Regardez YouTube sans publicités !",
+          "descriptionText": "Notre navigateur bloque désormais les publicités sur YouTube, pour des vidéos sans interruption."
+        },
+        "fr-BE": {
+          "titleText": "Regardez YouTube sans publicités !",
+          "descriptionText": "Notre navigateur bloque désormais les publicités sur YouTube, pour des vidéos sans interruption."
+        },
+        "de-DE": {
+          "titleText": "YouTube ohne Werbung ansehen!",
+          "descriptionText": "Unser Browser blockiert jetzt Werbung in YouTube-Videos, sodass du ohne Unterbrechung schauen kannst."
+        },
+        "de-AT": {
+          "titleText": "YouTube ohne Werbung ansehen!",
+          "descriptionText": "Unser Browser blockiert jetzt Werbung in YouTube-Videos, sodass du ohne Unterbrechung schauen kannst."
+        },
+        "de-LU": {
+          "titleText": "YouTube ohne Werbung ansehen!",
+          "descriptionText": "Unser Browser blockiert jetzt Werbung in YouTube-Videos, sodass du ohne Unterbrechung schauen kannst."
+        },
+        "de-BE": {
+          "titleText": "YouTube ohne Werbung ansehen!",
+          "descriptionText": "Unser Browser blockiert jetzt Werbung in YouTube-Videos, sodass du ohne Unterbrechung schauen kannst."
+        },
+        "nl-NL": {
+          "titleText": "Bekijk YouTube zonder advertenties!",
+          "descriptionText": "Onze browser blokkeert nu advertenties bij YouTube-video's, zodat je ongestoord kunt kijken."
+        },
+        "nl-BE": {
+          "titleText": "Bekijk YouTube zonder advertenties!",
+          "descriptionText": "Onze browser blokkeert nu advertenties bij YouTube-video's, zodat je ongestoord kunt kijken."
+        },
+        "it-IT": {
+          "titleText": "Guarda YouTube senza annunci!",
+          "descriptionText": "Ora il nostro browser blocca gli annunci nei video di YouTube, così puoi guardarli senza interruzioni."
+        },
+        "es-ES": {
+          "titleText": "¡Mira YouTube sin anuncios!",
+          "descriptionText": "Nuestro navegador ahora bloquea los anuncios en vídeos de YouTube, para que puedas verlos sin interrupciones."
+        },
+        "pl-PL": {
+          "titleText": "Oglądaj YouTube bez reklam!",
+          "descriptionText": "Nasza przeglądarka blokuje teraz reklamy na filmach YouTube, dzięki czemu możesz oglądać bez przerwy."
+        },
+        "pt-PT": {
+          "titleText": "Vê o YouTube sem anúncios!",
+          "descriptionText": "Agora, o nosso navegador bloqueia anúncios nos vídeos do YouTube para que possas assistir sem interrupções."
+        },
+        "ru-RU": {
+          "titleText": "Смотрите YouTube без рекламы!",
+          "descriptionText": "Наш браузер теперь блокирует рекламу на YouTube, так что вы можете смотреть без перерывов."
+        }
+      },
+      "matchingRules": [ 18 ],
+      "exclusionRules": [ 20 ]
+    },
+    {
+      "id": "funnel_newtab_adblockermf_windows2",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Block ads on YouTube!",
+        "descriptionText": "Our browser now blocks ads directly on YouTube, plus you can still use Duck Player as a private theater mode.",
+        "placeholder": "YoutubeNew"
+      },
+      "translations": {
+        "fr-FR": {
+          "titleText": "Bloquez les publicités sur YouTube !",
+          "descriptionText": "Notre navigateur bloque désormais les publicités directement sur YouTube. Duck Player reste disponible si vous avez besoin d’un mode « salle de projection privée »."
+        },
+        "fr-CA": {
+          "titleText": "Bloquez les publicités sur YouTube !",
+          "descriptionText": "Notre navigateur bloque désormais les publicités directement sur YouTube. Duck Player reste disponible si vous avez besoin d’un mode « salle de projection privée »."
+        },
+        "fr-LU": {
+          "titleText": "Bloquez les publicités sur YouTube !",
+          "descriptionText": "Notre navigateur bloque désormais les publicités directement sur YouTube. Duck Player reste disponible si vous avez besoin d’un mode « salle de projection privée »."
+        },
+        "fr-BE": {
+          "titleText": "Bloquez les publicités sur YouTube !",
+          "descriptionText": "Notre navigateur bloque désormais les publicités directement sur YouTube. Duck Player reste disponible si vous avez besoin d’un mode « salle de projection privée »."
+        },
+        "de-DE": {
+          "titleText": "Werbung auf YouTube blockieren!",
+          "descriptionText": "Unser Browser blockiert ab sofort Werbung direkt auf YouTube, außerdem kannst du Duck Player weiterhin als privaten Theatermodus nutzen."
+        },
+        "de-AT": {
+          "titleText": "Werbung auf YouTube blockieren!",
+          "descriptionText": "Unser Browser blockiert ab sofort Werbung direkt auf YouTube, außerdem kannst du Duck Player weiterhin als privaten Theatermodus nutzen."
+        },
+        "de-LU": {
+          "titleText": "Werbung auf YouTube blockieren!",
+          "descriptionText": "Unser Browser blockiert ab sofort Werbung direkt auf YouTube, außerdem kannst du Duck Player weiterhin als privaten Theatermodus nutzen."
+        },
+        "de-BE": {
+          "titleText": "Werbung auf YouTube blockieren!",
+          "descriptionText": "Unser Browser blockiert ab sofort Werbung direkt auf YouTube, außerdem kannst du Duck Player weiterhin als privaten Theatermodus nutzen."
+        },
+        "nl-NL": {
+          "titleText": "Blokkeer advertenties op YouTube!",
+          "descriptionText": "Onze browser blokkeert advertenties nu direct op YouTube, en je kunt Duck Player nog steeds gebruiken als theater modus."
+        },
+        "nl-BE": {
+          "titleText": "Blokkeer advertenties op YouTube!",
+          "descriptionText": "Onze browser blokkeert advertenties nu direct op YouTube, en je kunt Duck Player nog steeds gebruiken als theater modus."
+        },
+        "it-IT": {
+          "titleText": "Blocca gli annunci su YouTube!",
+          "descriptionText": "Ora il nostro browser blocca gli annunci direttamente su YouTube e puoi ancora utilizzare Duck Player come modalità cinema privata."
+        },
+        "es-ES": {
+          "titleText": "¡Bloquea anuncios en YouTube!",
+          "descriptionText": "Nuestro navegador ahora bloquea los anuncios directamente en YouTube; además, puedes seguir usando Duck Player en modo cine."
+        },
+        "pl-PL": {
+          "titleText": "Blokuj reklamy na YouTube!",
+          "descriptionText": "Nasza przeglądarka blokuje teraz reklamy bezpośrednio na YouTube, a ponadto nadal możesz używać Duck Playera w prywatnym trybie kina."
+        },
+        "pt-PT": {
+          "titleText": "Bloqueia anúncios no YouTube!",
+          "descriptionText": "O nosso navegador agora bloqueia anúncios diretamente no YouTube, além disso, ainda podes usar o Duck Player como modo de teatro privado."
+        },
+        "ru-RU": {
+          "titleText": "Блокировка рекламы на YouTube",
+          "descriptionText": "Наш браузер теперь блокирует рекламу прямо на YouTube, плюс вы по-прежнему можете использовать Duck Player для режима частного кинотеатра."
+        }
+      },
+      "matchingRules": [ 19 ],
+      "exclusionRules": [ 21 ]
     }
   ],
   "rules": [
@@ -273,6 +419,38 @@
         },
         "sync": {
           "value": false
+        }
+      }
+    },
+    {
+      "id": 18,
+      "attributes": {
+        "duckPlayerEnabled": {
+          "value": false
+        }
+      }
+    },
+    {
+      "id": 19,
+      "attributes": {
+        "duckPlayerEnabled": {
+          "value": true
+        }
+      }
+    },
+    {
+      "id": 20,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": [ "funnel_newtab_adblockermf_windows2" ]
+        }
+      }
+    },
+    {
+      "id": 21,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": [ "funnel_newtab_adblockermf_windows1" ]
         }
       }
     }


### PR DESCRIPTION
Adds a pair of youtube ad block promo messages as detailed in the below tasks.

https://app.asana.com/1/137249556945/project/1207619243206445/task/1214896260901188
https://app.asana.com/1/137249556945/project/1207619243206445/task/1214896260901208

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only remote messaging changes with no app logic or security impact; main review focus is correct rule IDs and copy/targeting.
> 
> **Overview**
> Bumps **Windows remote config** to version **64** and adds two **medium** new-tab funnel messages promoting **YouTube ad blocking** on Windows (`funnel_newtab_adblockermf_windows1` / `windows2`), with localized copy across FR, DE, NL, IT, ES, PL, PT, and RU.
> 
> **Targeting:** users with **`duckPlayerEnabled: false`** see the “watch without ads” variant; users with **`duckPlayerEnabled: true`** see copy that also mentions **Duck Player** as private theater mode. **Cross-exclusion** rules hide each message if the user already interacted with the other variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0662ac0b605c7890e44059b1358d60f560bf2bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->