### PR TITLE
Update PIR freemium RMF copy per ship review

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -362,9 +362,9 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Personal Information Removal",
-        "descriptionText": "Find your personal info on sites that sell it.",
+        "descriptionText": "DuckDuckGo will find your personal info on sites that store and sell it.",
         "placeholder": "PIR",
-        "primaryActionText": "Free Scan",
+        "primaryActionText": "Start Free Scan",
         "primaryAction": {
           "type": "navigation",
           "value": "pir.main"

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 113,
+  "version": 114,
   "messages": [
     {
       "id": "ios_privacy_pro_exit_survey_1",


### PR DESCRIPTION
## Summary

Reword the Personal Information Removal freemium message on iOS, per ship review feedback.

- **descriptionText**: "Find your personal info on sites that sell it." → "DuckDuckGo will find your personal info on sites that store and sell it."
- **primaryActionText**: "Free Scan" → "Start Free Scan"

## Scope

`live/ios-config/ios-config.json` only — copy-only change to the existing `big_single_action` PIR message; no targeting, IDs, or actions touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only remote config change with no logic, targeting, or action changes.
> 
> **Overview**
> Updates the iOS remote messaging config (**version 114**) with revised copy for the **Personal Information Removal** freemium new-tab message (`ios_pir_freemium_entry_point`).
> 
> The **description** now states that DuckDuckGo will find personal info on sites that **store and sell** it (not only “sell”). The primary CTA label changes from **“Free Scan”** to **“Start Free Scan”**. Message targeting, surfaces, IDs, and the `pir.main` navigation action are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cbbafa8a51df717919b18f9039333a18c230162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->