### PR TITLE
[Android] What's new message July 2026

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -761,6 +761,7 @@
         "titleText": "What's New",
         "descriptionText": "What's new in DuckDuckGo.",
         "placeholder": "DDGAnnounce",
+        "imageUrl": "https://staticcdn.duckduckgo.com/remotemessaging/illustrations/duckduckgo-feature-96-2-4x.png",
         "primaryActionText": "Dismiss",
         "primaryAction": {
           "type": "dismiss",

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1582,6 +1582,9 @@
         },
         "daysSinceInstalled": {
           "min": 7
+        },
+        "appVersion": {
+          "min": "5.288.0"
         }
       }
     }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -363,7 +363,9 @@
         "descriptionText": "After August 14, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
         "placeholder": "CriticalUpdate"
       },
-      "matchingRules": [25]
+      "matchingRules": [
+        25
+      ]
     },
     {
       "id": "android_deprecation_urgent_notice_os8_ppro",
@@ -378,7 +380,9 @@
           "value": "https://duckduckgo.com/subscription-support"
         }
       },
-      "matchingRules": [26]
+      "matchingRules": [
+        26
+      ]
     },
     {
       "id": "android_privacy_pro_exit_survey_1",
@@ -745,6 +749,60 @@
       ],
       "exclusionRules": [
         3
+      ]
+    },
+    {
+      "id": "whats_new_q2_2026",
+      "surfaces": [
+        "modal"
+      ],
+      "content": {
+        "messageType": "cards_list",
+        "titleText": "What's New",
+        "descriptionText": "What's new in DuckDuckGo.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "listItems": [
+          {
+            "id": "sync_duck_ai_chats_across_devices",
+            "type": "two_line_list_item",
+            "titleText": "Sync Duck.ai Chats Across Devices",
+            "descriptionText": "Sync your chats across desktop and mobile by visiting Duck.ai Settings > Sync & Backup.",
+            "placeholder": "Duck.ai",
+            "imageUrl": "https://staticcdn.duckduckgo.com/remotemessaging/illustrations/duckai-chat-feature-96-4x.png",
+            "primaryAction": {
+              "type": "url",
+              "value": "https://duck.ai/"
+            }
+          },
+          {
+            "id": "browse_with_fire_tabs",
+            "type": "two_line_list_item",
+            "titleText": "Browse with Fire Tabs",
+            "descriptionText": "Use Fire Tabs to isolate your browsing from normal tabs and browse without saving local history.",
+            "placeholder": "Announce",
+            "imageUrl": "https://staticcdn.duckduckgo.com/remotemessaging/illustrations/fire-feature-96-4x.png"
+          },
+          {
+            "id": "explore_more_subscription_options",
+            "type": "two_line_list_item",
+            "titleText": "Explore More Subscription Options",
+            "descriptionText": "Pick from two plans: Plus (for all four protections) or Pro (for more powerful AI functionality).",
+            "placeholder": "PrivacyShield",
+            "imageUrl": "https://staticcdn.duckduckgo.com/remotemessaging/illustrations/subscription-feature-96-4x.png",
+            "primaryAction": {
+              "type": "url",
+              "value": "https://duckduckgo.com/pro/plans?origin=funnel_whatsnew_androidrmf_julyxxvi"
+            }
+          }
+        ]
+      },
+      "matchingRules": [
+        33
       ]
     },
     {
@@ -1510,6 +1568,19 @@
       "attributes": {
         "fireModeUsed": {
           "value": true
+        }
+      }
+    },
+    {
+      "id": 33,
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US"
+          ]
+        },
+        "daysSinceInstalled": {
+          "min": 7
         }
       }
     }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -797,7 +797,7 @@
             "imageUrl": "https://staticcdn.duckduckgo.com/remotemessaging/illustrations/subscription-feature-96-4x.png",
             "primaryAction": {
               "type": "url",
-              "value": "https://duckduckgo.com/pro/plans?origin=funnel_whatsnew_androidrmf_julyxxvi"
+              "value": "https://duckduckgo.com/pro/plans?origin=funnel_whatsnew_android_julyxxvi"
             }
           }
         ]

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -780,10 +780,10 @@
             }
           },
           {
-            "id": "browse_with_fire_tabs",
+            "id": "burn_single_tabs",
             "type": "two_line_list_item",
-            "titleText": "Browse with Fire Tabs",
-            "descriptionText": "Use Fire Tabs to isolate your browsing from normal tabs and browse without saving local history.",
+            "titleText": "Burn Single Tabs",
+            "descriptionText": "Enjoy the option to burn individual tabs or Duck.ai chats with the Fire Button.",
             "placeholder": "Announce",
             "imageUrl": "https://staticcdn.duckduckgo.com/remotemessaging/illustrations/fire-feature-96-4x.png"
           },

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 111,
+  "version": 112,
   "messages": [
     {
       "id": "android_ntp_after_idle_existing_users_without_hatch_2026",


### PR DESCRIPTION
**Asana:** https://app.asana.com/1/137249556945/task/1216333217991497?focus=true

**Description:** 
See https://app.asana.com/1/137249556945/project/1207619243206445/task/1216315422229148?focus=true

**Testing:**
Verify what's new cards are displayed and matches the requested specs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote messaging JSON only; no client or security logic changes. Wrong rules or copy would affect in-app promos for the matched cohort only.
> 
> **Overview**
> Bumps **android-config** version to **112** and adds a new modal **What's New** message (`whats_new_q2_2026`) with three cards: Duck.ai chat sync across devices, burning single tabs via the Fire Button, and Plus/Pro subscription options (with URL actions where applicable).
> 
> Targeting uses new rule **33**: `en-US` locale, at least **7** days since install, and app version **≥ 5.288.0**. Two existing deprecation messages only change `matchingRules` JSON formatting (same rule IDs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef40d748b368bd1984ae7082bdc37c906934cc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->