### PR TITLE
remove windows promos

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 64,
+  "version": 65,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -74,38 +74,6 @@
         11,
         14
       ]
-    },
-    {
-      "id": "windows_stable_previewpromo_2026_2",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Be the first to try our newest features!",
-        "descriptionText": "Get DuckDuckGo Preview for Windows, and try the latest features before anyone else.",
-        "placeholder": "Preview",
-        "primaryActionText": "Get Early Access",
-        "primaryAction": {
-          "type": "url",
-          "value": "https://duckduckgo.com/windows-preview"
-        }
-      },
-      "matchingRules": [ 16 ],
-      "exclusionRules": []
-    },
-    {
-      "id": "windows_preview_syncpromo_2026",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Set up Sync on DuckDuckGo Preview",
-        "descriptionText": "Using a previous version of our browser on Windows? Sync your passwords & bookmarks.",
-        "placeholder": "Preview",
-        "primaryActionText": "Set Up Sync",
-        "primaryAction": {
-          "type": "url",
-          "value": "duck://settings/sync"
-        }
-      },
-      "matchingRules": [ 17 ],
-      "exclusionRules": []
     },
     {
       "id": "funnel_newtab_adblockermf_windows1",
@@ -380,45 +348,6 @@
       "attributes": {
         "interactedWithMessage": {
           "value": [ "windows_onboarding_v4_survey" ]
-        }
-      }
-    },
-    {
-      "id": 16,
-      "targetPercentile": {
-        "before": 0.40
-      },
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB"
-          ]
-        },
-        "flavor": {
-          "value": [ "stable" ]
-        },
-        "defaultBrowser": {
-          "value": false
-        }
-      }
-    },
-    {
-      "id": 17,
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB"
-          ]
-        },
-        "flavor": {
-          "value": [ "preview" ]
-        },
-        "sync": {
-          "value": false
         }
       }
     },


### PR DESCRIPTION
This removes the preview and sync promos - see https://app.asana.com/1/137249556945/task/1215906794323811

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only removal of promotional messages; no app logic or security-sensitive changes.
> 
> **Overview**
> **Removes two Windows in-app promos** and bumps `windows-config.json` from version **64** to **65**.
> 
> The **stable** early-access promo (`windows_stable_previewpromo_2026_2`) and the **preview** Sync setup promo (`windows_preview_syncpromo_2026`) are deleted from `messages`. Their targeting rules (**16** and **17**)—locale/flavor/default-browser and preview/sync attributes—are removed from `rules` as well.
> 
> Other messages (surveys, YouTube ad-blocker funnel) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e313a49e55a41aa6c0af92fc9d664361607df72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->