### PR TITLE
iOS: NTP After Idle Promo RMF

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 115,
+  "version": 116,
   "messages": [
     {
       "id": "ios_pir_announcement_1",
@@ -636,7 +636,193 @@
       "matchingRules": [
         23
       ],
-      "exclusionRules": []
+      "exclusionRules": [
+        30
+      ]
+    },
+    {
+      "id": "ios_ntp_after_idle_existing_users_without_hatch_2026",
+      "surfaces": [
+        "new_tab_page"
+      ],
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "Start searching faster!",
+        "descriptionText": "We now give you a fresh tab when you open the app.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Got It",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Customize",
+        "secondaryAction": {
+          "type": "navigation",
+          "value": "settings.general"
+        }
+      },
+      "translations": {
+        "bg": {
+          "titleText": "Започнете да търсите по-бързо!",
+          "descriptionText": "Сега при отваряне на приложението се отваря нов раздел.",
+          "primaryActionText": "Разбрах",
+          "secondaryActionText": "Персонализирай"
+        },
+        "cs": {
+          "titleText": "Začni vyhledávat rychleji!",
+          "descriptionText": "Nyní ti při otevření aplikace zobrazíme novou kartu.",
+          "primaryActionText": "Rozumím",
+          "secondaryActionText": "Přizpůsobit"
+        },
+        "da": {
+          "titleText": "Begynd at søge hurtigere!",
+          "descriptionText": "Vi giver dig nu en ny fane, når du åbner appen.",
+          "primaryActionText": "Forstået",
+          "secondaryActionText": "Tilpas"
+        },
+        "de": {
+          "titleText": "Suchen schneller starten!",
+          "descriptionText": "Beim Öffnen der App stellen wir dir jetzt direkt einen neuen Tab zur Verfügung.",
+          "primaryActionText": "Verstanden",
+          "secondaryActionText": "Anpassen"
+        },
+        "el": {
+          "titleText": "Ξεκίνα την αναζήτηση πιο γρήγορα!",
+          "descriptionText": "Πλέον, σου δίνουμε μια νέα καρτέλα όταν ανοίγεις την εφαρμογή.",
+          "primaryActionText": "Κατάλαβα",
+          "secondaryActionText": "Προσαρμογή"
+        },
+        "es": {
+          "titleText": "¡Empieza a buscar más rápido!",
+          "descriptionText": "Ahora, cuando abres la aplicación, se abre una pestaña nueva.",
+          "primaryActionText": "Entendido",
+          "secondaryActionText": "Personalizar"
+        },
+        "et": {
+          "titleText": "Alusta otsimist kiiremini!",
+          "descriptionText": "Nüüd kuvatakse rakenduse avamisel uus vahekaart.",
+          "primaryActionText": "Sain aru",
+          "secondaryActionText": "Kohanda"
+        },
+        "fi": {
+          "titleText": "Aloita haku nopeammin!",
+          "descriptionText": "Saat nyt uuden välilehden, kun avaat sovelluksen.",
+          "primaryActionText": "Selvä",
+          "secondaryActionText": "Mukauta"
+        },
+        "fr": {
+          "titleText": "Lancez vos recherches plus vite !",
+          "descriptionText": "Désormais, un nouvel onglet s'ouvre lorsque vous lancez l'application.",
+          "primaryActionText": "J'ai compris",
+          "secondaryActionText": "Personnaliser"
+        },
+        "hr": {
+          "titleText": "Kreni brže pretraživati!",
+          "descriptionText": "Kada otvoriš aplikaciju, čeka te nova kartica.",
+          "primaryActionText": "U redu",
+          "secondaryActionText": "Prilagodi"
+        },
+        "hu": {
+          "titleText": "Kezdj el gyorsabban keresni!",
+          "descriptionText": "Mostantól új lapot nyitunk, amikor visszatérsz az appba.",
+          "primaryActionText": "Értem",
+          "secondaryActionText": "Testreszabás"
+        },
+        "it": {
+          "titleText": "Inizia a cercare più velocemente!",
+          "descriptionText": "Ora ti offriamo una nuova scheda quando apri l'app.",
+          "primaryActionText": "Ho capito",
+          "secondaryActionText": "Personalizza"
+        },
+        "ja": {
+          "titleText": "もっと速く検索しよう！",
+          "descriptionText": "アプリを開くと、新しいタブが表示されるようになりました。",
+          "primaryActionText": "了解",
+          "secondaryActionText": "カスタマイズ"
+        },
+        "lt": {
+          "titleText": "Pradėkite ieškoti greičiau!",
+          "descriptionText": "Dabar, kai atidarote programėlę, pateikiame naują skirtuką.",
+          "primaryActionText": "Supratau",
+          "secondaryActionText": "Pritaikyti"
+        },
+        "lv": {
+          "titleText": "Sāc meklēt ātrāk!",
+          "descriptionText": "Tagad, atverot lietotni, tiek atvērta jauna cilne.",
+          "primaryActionText": "Sapratu",
+          "secondaryActionText": "Pielāgot"
+        },
+        "nb": {
+          "titleText": "Begynn å søke raskere!",
+          "descriptionText": "Vi gir deg nå en ny fane når du åpner appen.",
+          "primaryActionText": "Den er grei",
+          "secondaryActionText": "Tilpass"
+        },
+        "nl": {
+          "titleText": "Begin sneller met zoeken!",
+          "descriptionText": "Je krijgt nu een nieuw tabblad als je de app opent.",
+          "primaryActionText": "Ik snap het",
+          "secondaryActionText": "Aanpassen"
+        },
+        "pl": {
+          "titleText": "Wyszukuj szybciej!",
+          "descriptionText": "Teraz po otwarciu aplikacji dostajesz nową kartę.",
+          "primaryActionText": "Rozumiem",
+          "secondaryActionText": "Dostosuj"
+        },
+        "pt": {
+          "titleText": "Faz pesquisas mais rápidas!",
+          "descriptionText": "Agora apresentamos um separador novo quando abres a aplicação.",
+          "primaryActionText": "Entendi",
+          "secondaryActionText": "Personalizar"
+        },
+        "ro": {
+          "titleText": "Începe să cauți mai repede!",
+          "descriptionText": "Acum îți oferim o filă nouă atunci când deschizi aplicația.",
+          "primaryActionText": "Am înțeles",
+          "secondaryActionText": "Personalizează"
+        },
+        "ru": {
+          "titleText": "Ищи быстрее!",
+          "descriptionText": "Теперь при открытии приложения открывается новая вкладка.",
+          "primaryActionText": "Понятно",
+          "secondaryActionText": "Настроить"
+        },
+        "sk": {
+          "titleText": "Začni vyhľadávať rýchlejšie!",
+          "descriptionText": "Teraz ti pri otvorení aplikácie zobrazíme novú kartu.",
+          "primaryActionText": "Rozumiem",
+          "secondaryActionText": "Prispôsobiť"
+        },
+        "sl": {
+          "titleText": "Začni iskati hitreje!",
+          "descriptionText": "Zdaj vam ob odprtju aplikacije ponudimo nov zavihek.",
+          "primaryActionText": "Razumem",
+          "secondaryActionText": "Prilagodi"
+        },
+        "sv": {
+          "titleText": "Börja söka snabbare!",
+          "descriptionText": "Vi ger dig nu en ny flik när du öppnar appen.",
+          "primaryActionText": "Jag förstår",
+          "secondaryActionText": "Anpassa"
+        },
+        "tr": {
+          "titleText": "Daha hızlı aramaya başla!",
+          "descriptionText": "Uygulamayı açtığınızda artık karşınıza yeni bir sekme çıkar.",
+          "primaryActionText": "Anladım",
+          "secondaryActionText": "Özelleştir"
+        }
+      },
+      "displayConditions": {
+        "trigger": "after_idle",
+        "dismissAfterDaysShown": 5
+      },
+      "matchingRules": [
+        29
+      ],
+      "exclusionRules": [
+        31
+      ]
     },
     {
       "id": "funnel_newtab_adblockermf_ios1a",
@@ -1338,10 +1524,13 @@
       "id": 23,
       "attributes": {
         "appVersion": {
-          "min": "7.220.0"
+          "min": "7.227.0"
         },
         "daysSinceInstalled": {
           "min": 58
+        },
+        "ntpAfterIdleState": {
+          "value": ["eligibleCardShown"]
         }
       }
     },
@@ -1548,6 +1737,36 @@
         },
         "locale": {
           "value": ["en-US"]
+        }
+      }
+    },
+    {
+      "id": 29,
+      "attributes": {
+        "appVersion": {
+          "min": "7.227.0"
+        },
+        "daysSinceInstalled": {
+          "min": 58
+        },
+        "ntpAfterIdleState": {
+          "value": ["eligibleCardHidden"]
+        }
+      }
+    },
+    {
+      "id": 30,
+      "attributes": {
+        "messageShown": {
+          "value": ["ios_ntp_after_idle_existing_users_without_hatch_2026"]
+        }
+      }
+    },
+    {
+      "id": 31,
+      "attributes": {
+        "messageShown": {
+          "value": ["ios_ntp_after_idle_existing_users_2026"]
         }
       }
     }

--- a/schemas/ios/schema.json
+++ b/schemas/ios/schema.json
@@ -427,7 +427,8 @@
             "subscriptionFreeTrialActive": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
             "syncEnabled": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
             "shouldShowWinBackOfferUrgencyMessage": { "$ref": "#/definitions/SingleValueBooleanAttribute" },
-            "daysSinceDuckAiUsed": { "$ref": "#/definitions/NumericRangeAttribute" }
+            "daysSinceDuckAiUsed": { "$ref": "#/definitions/NumericRangeAttribute" },
+            "ntpAfterIdleState": { "$ref": "#/definitions/SingleValueStringArrayAttribute" }
           },
           "additionalProperties": false
         }


### PR DESCRIPTION
Task: https://app.asana.com/1/137249556945/project/1204186595873227/task/1216509643570132?focus=true
**Description**
Gates the existing iOS NTP after idle promo on the new `ntpAfterIdleState` matching attribute (shipped in iOS 7.227.0, duckduckgo/apple-browsers#5536) and adds a second copy for users without the return-to-tab card, following the two-copy design from the matching attribute task (Android equivalent: #376):

- `ios_ntp_after_idle_existing_users_2026` — **unchanged copy and translations**; now matches `ntpAfterIdleState: eligibleCardShown` and requires app version 7.227.0+
- `ios_ntp_after_idle_existing_users_without_hatch_2026` — **new**; cloned from the original with the "return to your last used tab" sentence removed from the English copy and every translation; matches `eligibleCardHidden`

The two messages are mutually exclusive via reciprocal `messageShown` exclusion rules: a user who has seen one copy is never shown the other, even if they toggle the hatch setting afterwards. Also adds `ntpAfterIdleState` to the iOS schema.

**Testing steps**
1. In the iOS debug menu, override the RMF config URL with this PR's raw config:
   `https://raw.githubusercontent.com/duckduckgo/remote-messaging-config/refs/heads/sabrina/ios-ntp-after-idle-promo/live/ios-config/ios-config.json`
2. Settings → General → After Inactivity: set open on launch to **New Tab Page**, and set the inactivity time to 0 so any backgrounding counts as idle
3. **With the return-to-tab card enabled**: background and reopen the app so it lands on the after-idle NTP → the original message ("Start searching faster!", copy mentioning "the link above") should show
4. **With the return-to-tab card disabled** (on a state that hasn't seen the first message): repeat → the no-hatch message (same copy without the last sentence) should show
5. **Mutual exclusion**: after one copy has been displayed, toggle the card setting and go idle again → the other copy must NOT appear
6. Sanity: neither message appears on a regular (non-after-idle) NTP, or when open on launch is not New Tab Page (`notEligible`)

Note for testers: the matching rules also require `appVersion ≥ 7.227.0` and `daysSinceInstalled ≥ 58`, so a fresh debug install won't match — use the debug override for install date if available, or test with a locally edited copy of the config with those two attributes removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote messaging config and schema only; no app logic changes, with targeting limited to existing long-tenure users on 7.227.0+.
> 
> **Overview**
> Bumps iOS remote messaging config to **v116** and wires the existing after-idle NTP promo to the new **`ntpAfterIdleState`** client attribute (7.227.0+).
> 
> **`ios_ntp_after_idle_existing_users_2026`** now requires **`eligibleCardShown`** (rule 23: min app **7.227.0**, `daysSinceInstalled ≥ 58`) and excludes users who already saw the no-hatch copy (exclusion rule 30).
> 
> Adds **`ios_ntp_after_idle_existing_users_without_hatch_2026`**: same promo shell and locales, but copy drops the “return to last tab” sentence; it matches **`eligibleCardHidden`** (rule 29) and excludes anyone who saw the hatch copy (rule 31). Reciprocal **`messageShown`** exclusions keep the two variants mutually exclusive even if the return-to-tab card setting changes later.
> 
> The iOS JSON schema now allows **`ntpAfterIdleState`** on matching rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b0bf8126e317434d10663d69a95afc91fb66f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->