### PR TITLE
Android: Update minSdk deprecation date

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,12 +1,12 @@
 {
-  "version": 106,
+  "version": 107,
   "messages": [
     {
       "id": "android_deprecation_urgent_notice_os8",
       "content": {
         "messageType": "medium",
         "titleText": "Important reminder: Upgrade to Android 9 or higher to stay protected",
-        "descriptionText": "After July 15, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
+        "descriptionText": "After July 23, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
         "placeholder": "CriticalUpdate"
       },
       "matchingRules": [25]
@@ -16,7 +16,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Important reminder: Upgrade to Android 9 or request subscription refund",
-        "descriptionText": "After July 15, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
+        "descriptionText": "After July 23, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
         "placeholder": "CriticalUpdate",
         "primaryActionText": "Request Subscription Refund",
         "primaryAction": {


### PR DESCRIPTION
Updated version number and modified deprecation notice dates.
https://app.asana.com/1/137249556945/project/414730916066338/task/1211797465357968?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and config version only; no app logic, auth, or enforcement changes in this diff.
> 
> **Overview**
> Bumps **`live/android-config/android-config.json`** from version **106** to **107** so clients pick up the updated remote config.
> 
> Updates the Android 8 / 8.1 end-of-support date in **`descriptionText`** from **July 15, 2026** to **July 23, 2026** on both urgent deprecation messages (`android_deprecation_urgent_notice_os8` and `android_deprecation_urgent_notice_os8_ppro`). Titles, matching rules, and other copy are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e66c5fe21520275c81f8394edfc7a91f8ea430a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->