### PR TITLE
Android: Add Internal Message Annoyance Survey

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -392,6 +392,31 @@
       "exclusionRules": [
         3
       ]
+    },
+    {
+      "id": "internal_message_annoyance_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help us improve the app!",
+        "descriptionText": "Take our short anonymous survey and share your feedback.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/260701?list=2",
+          "additionalParameters": {
+            "queryParams": "var;delta;av;ddgv;last_search_state"
+          }
+        }
+      },
+      "matchingRules": [
+        27
+      ],
+      "exclusionRules": [
+        6,
+        7,
+        28
+      ]
     }
   ],
   "rules": [
@@ -945,6 +970,34 @@
         },
         "pproSubscriber": {
           "value": true
+        }
+      }
+    },
+    {
+      "id": 27,
+      "targetPercentile": {
+        "before": 0.2
+      },
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        }
+      }
+    },
+    {
+      "id": 28,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": [
+            "android_survey_net_attribute_rating_d0_3",
+            "android_permanent_survey_user_satisfaction",
+            "android_quarterly_mobile_survey_q226"
+          ]
         }
       }
     }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 108,
+  "version": 109,
   "messages": [
     {
       "id": "android_deprecation_urgent_notice_os8",
@@ -410,12 +410,12 @@
         }
       },
       "matchingRules": [
-        27
+        31
       ],
       "exclusionRules": [
         6,
         7,
-        28
+        32
       ]
     }
   ],
@@ -974,7 +974,7 @@
       }
     },
     {
-      "id": 27,
+      "id": 31,
       "targetPercentile": {
         "before": 0.2
       },
@@ -990,7 +990,7 @@
       }
     },
     {
-      "id": 28,
+      "id": 32,
       "attributes": {
         "interactedWithMessage": {
           "value": [


### PR DESCRIPTION
**Asana**: https://app.asana.com/1/137249556945/task/1216553772273286

**Description**: See https://app.asana.com/1/137249556945/project/1207619243206445/task/1216537067092452?focus=true

**Testing**:
Validate survey shows for qualified users

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote config-only change for survey messaging and audience rules; no app code or security-sensitive logic.
> 
> **Overview**
> Bumps **android-config** to version **109** and adds a new in-app message **`internal_message_annoyance_survey_1`** that prompts English-locale users to take a short Decipher survey (`260701`) about app annoyance, with survey URL query params including `last_search_state`.
> 
> Targeting uses new **rule 31** (20% rollout, `en-US` / `en-CA` / `en-GB` / `en-AU`). **Exclusion rule 32** suppresses the message for users who already interacted with related survey messages; exclusions **6** and **7** keep it from overlapping Privacy Pro subscriber/exit survey audiences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526f4fd340026c85013af16f0d6ecaaad7022774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->