### PR TITLE
Lower the iOS evergreen survey target percentile value

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 117,
+  "version": 118,
   "messages": [
     {
       "id": "ios_pir_announcement_1",
@@ -882,7 +882,7 @@
     {
       "id": 4,
       "targetPercentile": {
-        "before": 0.6
+        "before": 0.3
       },
       "attributes": {
         "daysSinceInstalled": {


### PR DESCRIPTION
See https://app.asana.com/1/137249556945/task/1208454188907378/comment/1216537067092456?focus=true.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote-config-only change to in-app message sampling; no app code or security-sensitive logic.
> 
> **Overview**
> Bumps **live iOS remote config** from version **117** to **118**.
> 
> For **matching rule 4** (the `ddg_ios_survey_1` evergreen “Help us improve the app!” survey), **`targetPercentile.before`** is reduced from **0.6** to **0.3**, narrowing which eligible users (14–21 days since install, min app **7.124.0.1**, en-US/CA/GB/AU) are included in the survey rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e52df4dce64db3af6606060e99dcc54dc38141fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->