### PR TITLE
iOS: Add Internal Message Annoyance Survey

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 118,
+  "version": 119,
   "messages": [
     {
       "id": "ios_pir_announcement_1",
@@ -366,6 +366,34 @@
       },
       "matchingRules": [
         4
+      ]
+    },
+
+    {
+      "id": "internal_message_annoyance_survey_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help us improve the app!",
+        "descriptionText": "Take our short anonymous survey and share your feedback.",
+        "placeholder": "Announce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/260701?list=4",
+          "additionalParameters": {
+            "queryParams": "var;delta;osv;ddgv;last_search_state"
+          }
+        }
+      },
+      "matchingRules": [
+        32
+      ],
+      "exclusionRules": [
+        1,
+        2,
+        17,
+        18,
+        33
       ]
     },
 
@@ -1349,6 +1377,33 @@
       "attributes": {
         "messageShown": {
           "value": ["ios_ntp_after_idle_existing_users_2026"]
+        }
+      }
+    },
+    {
+      "id": 32,
+      "targetPercentile": {
+        "before": 0.2
+      },
+      "attributes": {
+        "locale": {
+          "value": [
+            "en-US",
+            "en-CA",
+            "en-GB",
+            "en-AU"
+          ]
+        }
+      }
+    },
+    {
+      "id": 33,
+      "attributes": {
+        "interactedWithMessage": {
+          "value": [
+            "ddg_ios_survey_1",
+            "ios_quarterly_satisfaction_survey_q2_2026"
+          ]
         }
       }
     }


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/1/137249556945/project/1207619243206445/task/1216553808466279?focus=true

Adds the iOS equivalent of https://github.com/duckduckgo/remote-messaging-config/pull/387.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only remote messaging change with bounded rollout and exclusions; no app code or security-sensitive logic.
> 
> **Overview**
> Bumps **iOS remote messaging config** from version **118** to **119** and adds a new in-app message `internal_message_annoyance_survey_1` that prompts English-locale users to take a short Decipher survey about in-app messaging.
> 
> Targeting uses new **rule 32** (20% rollout via `targetPercentile.before: 0.2`, locales en-US/CA/GB/AU). **Exclusion rules** keep the prompt off Privacy Pro exit/subscriber survey cohorts (rules 1, 2, 17, 18) and users who already engaged with prior surveys (**rule 33**: `ddg_ios_survey_1`, `ios_quarterly_satisfaction_survey_q2_2026`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8d9af2eadd4281dc949955dd51229bf49752bbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->