### PR TITLE
Android: Remove net attribute rating survey

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 107,
+  "version": 108,
   "messages": [
     {
       "id": "android_deprecation_urgent_notice_os8",
@@ -392,26 +392,6 @@
       "exclusionRules": [
         3
       ]
-    },
-    {
-      "id": "android_survey_net_attribute_rating_d0_3",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help us improve the app!",
-        "descriptionText": "Take our short anonymous survey and share your feedback.",
-        "placeholder": "DDGAnnounce",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/260307",
-          "additionalParameters": {
-            "queryParams": "atb;var;delta;av;ddgv;man;mo;locale"
-          }
-        }
-      },
-      "matchingRules": [
-        2
-      ]
     }
   ],
   "rules": [
@@ -435,25 +415,6 @@
         "daysSinceInstalled": {
           "min": 14,
           "max": 21
-        }
-      }
-    },
-    {
-      "id": 2,
-      "targetPercentile": {
-        "before": 0.1
-      },
-      "attributes": {
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
-          ]
-        },
-        "daysSinceInstalled": {
-          "max": 3
         }
       }
     },


### PR DESCRIPTION
**Asana**: https://app.asana.com/1/137249556945/task/1213803796050102?focus=true

**Description**:
See https://app.asana.com/1/137249556945/project/1207619243206445/task/1213798658770663?focus=true

**Testing**:
Check that the survey is correctly removed based on the diff of the original PR https://github.com/duckduckgo/remote-messaging-config/pull/339

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only removal of a remote survey campaign; no app logic or security-sensitive changes.
> 
> **Overview**
> Bumps **Android remote messaging config** from version **107** to **108** and **removes** the in-app **net attribute rating** survey (`android_survey_net_attribute_rating_d0_3`), including its Decipher survey action and **matching rule 2** (English locales, ≤3 days since install, 10% percentile cap).
> 
> Other messages and rules are unchanged. **Rule 3** still lists the removed message id under `interactedWithMessage` (exclusion for `android_permanent_survey_user_satisfaction`); that reference is **not** updated in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1460ba71de62fce1a428a13380fb9a593cf9567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->