### PR TITLE
iOS: Set freemium PIR RMF entry point to 0%

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 118,
+  "version": 119,
   "messages": [
     {
       "id": "ios_pir_announcement_1",
@@ -1250,6 +1250,9 @@
     },
     {
       "id": 20,
+      "targetPercentile": {
+        "before": 0
+      },
       "attributes": {
         "isFreemiumPIREligible": {
           "value": true


### PR DESCRIPTION
## Asana task
https://app.asana.com/1/137249556945/task/1215657588370228

## What

Adds `targetPercentile: { before: 0 }` to matching rule `20` (used by the `ios_pir_freemium_entry_point` message) and bumps the iOS config version `118 → 119`.

## Why

Per the [rollout plan](https://app.asana.com/1/137249556945/project/1203581873609357/task/1215530017305256?focus=true) we intend to only turn on this message later.

## Scope

- Only rule `20` (the entry point) is changed.
- Scan-complete follow-up messages (rules `21` / `22`) are intentionally left untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote messaging config only; limits one NTP promo to 0% exposure with no app or security logic changes.
> 
> **Overview**
> Disables the **freemium PIR new-tab entry** (`ios_pir_freemium_entry_point`) by setting matching rule **20** to `targetPercentile: { before: 0 }`, so no eligible users receive that RMF until the percentile is raised per the rollout plan.
> 
> Bumps **`live/ios-config/ios-config.json`** version **118 → 119**. Scan-complete messages tied to rules **21** / **22** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a56bba57f4a41abe8edff002ce41ccda93d2936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->