### PR TITLE
Removed ad block messages for windows

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 65,
+  "version": 66,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -74,152 +74,6 @@
         11,
         14
       ]
-    },
-    {
-      "id": "funnel_newtab_adblockermf_windows1",
-      "content": {
-        "messageType": "medium",
-        "titleText": "Watch YouTube without ads!",
-        "descriptionText": "Our browser now blocks ads on YouTube videos, so you can watch without interruption.",
-        "placeholder": "YoutubeNew"
-      },
-      "translations": {
-        "fr-FR": {
-          "titleText": "Regardez YouTube sans publicités !",
-          "descriptionText": "Notre navigateur bloque désormais les publicités sur YouTube, pour des vidéos sans interruption."
-        },
-        "fr-CA": {
-          "titleText": "Regardez YouTube sans publicités !",
-          "descriptionText": "Notre navigateur bloque désormais les publicités sur YouTube, pour des vidéos sans interruption."
-        },
-        "fr-LU": {
-          "titleText": "Regardez YouTube sans publicités !",
-          "descriptionText": "Notre navigateur bloque désormais les publicités sur YouTube, pour des vidéos sans interruption."
-        },
-        "fr-BE": {
-          "titleText": "Regardez YouTube sans publicités !",
-          "descriptionText": "Notre navigateur bloque désormais les publicités sur YouTube, pour des vidéos sans interruption."
-        },
-        "de-DE": {
-          "titleText": "YouTube ohne Werbung ansehen!",
-          "descriptionText": "Unser Browser blockiert jetzt Werbung in YouTube-Videos, sodass du ohne Unterbrechung schauen kannst."
-        },
-        "de-AT": {
-          "titleText": "YouTube ohne Werbung ansehen!",
-          "descriptionText": "Unser Browser blockiert jetzt Werbung in YouTube-Videos, sodass du ohne Unterbrechung schauen kannst."
-        },
-        "de-LU": {
-          "titleText": "YouTube ohne Werbung ansehen!",
-          "descriptionText": "Unser Browser blockiert jetzt Werbung in YouTube-Videos, sodass du ohne Unterbrechung schauen kannst."
-        },
-        "de-BE": {
-          "titleText": "YouTube ohne Werbung ansehen!",
-          "descriptionText": "Unser Browser blockiert jetzt Werbung in YouTube-Videos, sodass du ohne Unterbrechung schauen kannst."
-        },
-        "nl-NL": {
-          "titleText": "Bekijk YouTube zonder advertenties!",
-          "descriptionText": "Onze browser blokkeert nu advertenties bij YouTube-video's, zodat je ongestoord kunt kijken."
-        },
-        "nl-BE": {
-          "titleText": "Bekijk YouTube zonder advertenties!",
-          "descriptionText": "Onze browser blokkeert nu advertenties bij YouTube-video's, zodat je ongestoord kunt kijken."
-        },
-        "it-IT": {
-          "titleText": "Guarda YouTube senza annunci!",
-          "descriptionText": "Ora il nostro browser blocca gli annunci nei video di YouTube, così puoi guardarli senza interruzioni."
-        },
-        "es-ES": {
-          "titleText": "¡Mira YouTube sin anuncios!",
-          "descriptionText": "Nuestro navegador ahora bloquea los anuncios en vídeos de YouTube, para que puedas verlos sin interrupciones."
-        },
-        "pl-PL": {
-          "titleText": "Oglądaj YouTube bez reklam!",
-          "descriptionText": "Nasza przeglądarka blokuje teraz reklamy na filmach YouTube, dzięki czemu możesz oglądać bez przerwy."
-        },
-        "pt-PT": {
-          "titleText": "Vê o YouTube sem anúncios!",
-          "descriptionText": "Agora, o nosso navegador bloqueia anúncios nos vídeos do YouTube para que possas assistir sem interrupções."
-        },
-        "ru-RU": {
-          "titleText": "Смотрите YouTube без рекламы!",
-          "descriptionText": "Наш браузер теперь блокирует рекламу на YouTube, так что вы можете смотреть без перерывов."
-        }
-      },
-      "matchingRules": [ 18 ],
-      "exclusionRules": [ 20 ]
-    },
-    {
-      "id": "funnel_newtab_adblockermf_windows2",
-      "content": {
-        "messageType": "medium",
-        "titleText": "Block ads on YouTube!",
-        "descriptionText": "Our browser now blocks ads directly on YouTube, plus you can still use Duck Player as a private theater mode.",
-        "placeholder": "YoutubeNew"
-      },
-      "translations": {
-        "fr-FR": {
-          "titleText": "Bloquez les publicités sur YouTube !",
-          "descriptionText": "Notre navigateur bloque désormais les publicités directement sur YouTube. Duck Player reste disponible si vous avez besoin d’un mode « salle de projection privée »."
-        },
-        "fr-CA": {
-          "titleText": "Bloquez les publicités sur YouTube !",
-          "descriptionText": "Notre navigateur bloque désormais les publicités directement sur YouTube. Duck Player reste disponible si vous avez besoin d’un mode « salle de projection privée »."
-        },
-        "fr-LU": {
-          "titleText": "Bloquez les publicités sur YouTube !",
-          "descriptionText": "Notre navigateur bloque désormais les publicités directement sur YouTube. Duck Player reste disponible si vous avez besoin d’un mode « salle de projection privée »."
-        },
-        "fr-BE": {
-          "titleText": "Bloquez les publicités sur YouTube !",
-          "descriptionText": "Notre navigateur bloque désormais les publicités directement sur YouTube. Duck Player reste disponible si vous avez besoin d’un mode « salle de projection privée »."
-        },
-        "de-DE": {
-          "titleText": "Werbung auf YouTube blockieren!",
-          "descriptionText": "Unser Browser blockiert ab sofort Werbung direkt auf YouTube, außerdem kannst du Duck Player weiterhin als privaten Theatermodus nutzen."
-        },
-        "de-AT": {
-          "titleText": "Werbung auf YouTube blockieren!",
-          "descriptionText": "Unser Browser blockiert ab sofort Werbung direkt auf YouTube, außerdem kannst du Duck Player weiterhin als privaten Theatermodus nutzen."
-        },
-        "de-LU": {
-          "titleText": "Werbung auf YouTube blockieren!",
-          "descriptionText": "Unser Browser blockiert ab sofort Werbung direkt auf YouTube, außerdem kannst du Duck Player weiterhin als privaten Theatermodus nutzen."
-        },
-        "de-BE": {
-          "titleText": "Werbung auf YouTube blockieren!",
-          "descriptionText": "Unser Browser blockiert ab sofort Werbung direkt auf YouTube, außerdem kannst du Duck Player weiterhin als privaten Theatermodus nutzen."
-        },
-        "nl-NL": {
-          "titleText": "Blokkeer advertenties op YouTube!",
-          "descriptionText": "Onze browser blokkeert advertenties nu direct op YouTube, en je kunt Duck Player nog steeds gebruiken als theater modus."
-        },
-        "nl-BE": {
-          "titleText": "Blokkeer advertenties op YouTube!",
-          "descriptionText": "Onze browser blokkeert advertenties nu direct op YouTube, en je kunt Duck Player nog steeds gebruiken als theater modus."
-        },
-        "it-IT": {
-          "titleText": "Blocca gli annunci su YouTube!",
-          "descriptionText": "Ora il nostro browser blocca gli annunci direttamente su YouTube e puoi ancora utilizzare Duck Player come modalità cinema privata."
-        },
-        "es-ES": {
-          "titleText": "¡Bloquea anuncios en YouTube!",
-          "descriptionText": "Nuestro navegador ahora bloquea los anuncios directamente en YouTube; además, puedes seguir usando Duck Player en modo cine."
-        },
-        "pl-PL": {
-          "titleText": "Blokuj reklamy na YouTube!",
-          "descriptionText": "Nasza przeglądarka blokuje teraz reklamy bezpośrednio na YouTube, a ponadto nadal możesz używać Duck Playera w prywatnym trybie kina."
-        },
-        "pt-PT": {
-          "titleText": "Bloqueia anúncios no YouTube!",
-          "descriptionText": "O nosso navegador agora bloqueia anúncios diretamente no YouTube, além disso, ainda podes usar o Duck Player como modo de teatro privado."
-        },
-        "ru-RU": {
-          "titleText": "Блокировка рекламы на YouTube",
-          "descriptionText": "Наш браузер теперь блокирует рекламу прямо на YouTube, плюс вы по-прежнему можете использовать Duck Player для режима частного кинотеатра."
-        }
-      },
-      "matchingRules": [ 19 ],
-      "exclusionRules": [ 21 ]
     }
   ],
   "rules": [
@@ -348,38 +202,6 @@
       "attributes": {
         "interactedWithMessage": {
           "value": [ "windows_onboarding_v4_survey" ]
-        }
-      }
-    },
-    {
-      "id": 18,
-      "attributes": {
-        "duckPlayerEnabled": {
-          "value": false
-        }
-      }
-    },
-    {
-      "id": 19,
-      "attributes": {
-        "duckPlayerEnabled": {
-          "value": true
-        }
-      }
-    },
-    {
-      "id": 20,
-      "attributes": {
-        "interactedWithMessage": {
-          "value": [ "funnel_newtab_adblockermf_windows2" ]
-        }
-      }
-    },
-    {
-      "id": 21,
-      "attributes": {
-        "interactedWithMessage": {
-          "value": [ "funnel_newtab_adblockermf_windows1" ]
         }
       }
     }


### PR DESCRIPTION
removed windows ad block messages - see https://app.asana.com/1/137249556945/task/1214336849870639

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only removal of in-app messaging; no auth, data, or client logic changes in this diff.
> 
> **Overview**
> Removes the Windows new-tab funnel that promoted YouTube ad blocking and Duck Player, bumping `windows-config.json` from version **65** to **66**.
> 
> **Deleted messages:** `funnel_newtab_adblockermf_windows1` and `funnel_newtab_adblockermf_windows2` (medium promos with localized copy and `YoutubeNew` placeholder), including their matching/exclusion rule links.
> 
> **Deleted rules:** IDs **18** and **19** (`duckPlayerEnabled` false/true) and **20**/**21** (interaction exclusions between the two funnel messages).
> 
> Privacy Pro and 14-day survey messages and their rules are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9f010a5c5d110d90eaef60a736d3bff5a98056e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->