### PR TITLE
[iOS] Auto-dismiss PIR promo 5 days after first shown

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 118,
+  "version": 119,
   "messages": [
     {
       "id": "ios_pir_announcement_1",
@@ -14,7 +14,10 @@
           "value": "pir.main"
         }
       },
-      "matchingRules": [28]
+      "matchingRules": [28],
+      "displayConditions": {
+        "dismissAfterDaysShown": 5
+      }
     },
     {
       "id": "ios_privacy_pro_exit_survey_1",


### PR DESCRIPTION
Asana: https://app.asana.com/1/137249556945/project/72649045549333/task/1216712289234241?focus=true

`ios_pir_announcement_1` re-appears on every new tab page until the user explicitly dismissed it. 

Add `dismissAfterDaysShown: 5` (mirroring the `ios_ntp_after_idle_existing_users_2026` promos) so it auto-dismisses 5 days after first display even without interaction. 

Eligibility:

To test this RMF, ensure the following conditions:

1. Version range check (between [iOS App Release 7.227.0](https://app.asana.com/1/137249556945/project/414235014887631/task/1216098939559529) and [iOS App Release 7.229.0](https://app.asana.com/1/137249556945/project/414235014887631/task/1216495131919414)) → this was meant to limit the exposure
1. Is subscriber, has active/expiring subscription
1. Is NOT current PIR user
1. US-locale, 50% rollout


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote messaging JSON-only change with no secrets; behavior is limited to promo display timing for an existing message.
> 
> **Overview**
> Bumps live iOS remote messaging config **version 118 → 119** and adds **`displayConditions.dismissAfterDaysShown: 5`** on **`ios_pir_announcement_1`**, using the same auto-dismiss pattern as the NTP after-idle promos.
> 
> Eligible subscribers who see the Personal Information Removal promo will stop seeing it **five days after first display**, even if they never tap dismiss—addressing repeat appearances on new tab until explicit dismissal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b45ec00168938e57448e393a34d1cd689c6154a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->