### PR TITLE
Android: Adjust deadline for minsdk update

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 109,
+  "version": 110,
   "messages": [
     {
       "id": "android_ntp_after_idle_existing_users_without_hatch_2026",
@@ -360,7 +360,7 @@
       "content": {
         "messageType": "medium",
         "titleText": "Important reminder: Upgrade to Android 9 or higher to stay protected",
-        "descriptionText": "After July 23, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
+        "descriptionText": "After August 14, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
         "placeholder": "CriticalUpdate"
       },
       "matchingRules": [25]
@@ -370,7 +370,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "Important reminder: Upgrade to Android 9 or request subscription refund",
-        "descriptionText": "After July 23, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
+        "descriptionText": "After August 14, 2026, DuckDuckGo will stop supporting Android 8 and 8.1. You can still use the browser, but updates and fixes will stop, and your privacy may be affected.",
         "placeholder": "CriticalUpdate",
         "primaryActionText": "Request Subscription Refund",
         "primaryAction": {


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/414730916066338/task/1216751571321120?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and config version bump only; no logic, rules, or app code changes.
> 
> **Overview**
> Bumps **`android-config.json`** from version **109** to **110** so clients pick up the update.
> 
> Updates the Android 8 / 8.1 end-of-support date in **`android_deprecation_urgent_notice_os8`** and **`android_deprecation_urgent_notice_os8_ppro`** from **July 23, 2026** to **August 14, 2026** in the English `descriptionText` only. Matching rules and other copy are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb11c6dafc35b9da330a2548fce6efbdc23fbce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->