### PR TITLE
Increase iOS PIR subscriber promo rollout to 100%

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 119,
+  "version": 120,
   "messages": [
     {
       "id": "ios_pir_announcement_1",
@@ -1307,7 +1307,7 @@
     {
       "id": 28,
       "targetPercentile": {
-        "before": 0.5
+        "before": 1.0
       },
       "attributes": {
         "pproSubscriber": {


### PR DESCRIPTION
Asana Task/Github Issue: https://app.asana.com/1/137249556945/project/1203581873609357/task/1213763847118555?focus=true

Increases the `ios_pir_announcement_1` RMF rollout from **50% to 100%** by bumping matching rule 28's `targetPercentile.before` from 0.5 to 1.0. Config version bumped to 120. Targeting is otherwise unchanged: en-US, active/expiring Privacy Pro subscribers who are not already PIR users, on app versions 7.227.0–7.229.0.

Completes the staged rollout started in #366.

Make sure to have your region set to US for this to show up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote messaging config only; no app logic or security changes, just widening an existing promo rollout.
> 
> **Overview**
> Completes the staged rollout of the **`ios_pir_announcement_1`** RMF by raising matching rule **28**’s `targetPercentile.before` from **0.5** to **1.0**, so every eligible user in the percentile bucket sees the promo instead of half.
> 
> Config **`version`** is bumped **119 → 120**. Audience and other rule attributes are unchanged (en-US Privacy Pro active/expiring subscribers who are not current PIR users, on app versions 7.227.0–7.229.0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e55304c0daa39b545737a83fc22ce45bcacddef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->