### PR TITLE
[iOS] Auto-dismiss freemium PIR entry point 5 days after first shown

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1260,6 +1260,9 @@
         "before": 0
       },
       "attributes": {
+        "appVersion": {
+          "min": "7.230.0"
+        },
         "isFreemiumPIREligible": {
           "value": true
         },
@@ -1274,6 +1277,9 @@
     {
       "id": 21,
       "attributes": {
+        "appVersion": {
+          "min": "7.230.0"
+        },
         "isFreemiumPIREligible": {
           "value": true
         },
@@ -1285,6 +1291,9 @@
     {
       "id": 22,
       "attributes": {
+        "appVersion": {
+          "min": "7.230.0"
+        },
         "isFreemiumPIREligible": {
           "value": true
         },

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 120,
+  "version": 121,
   "messages": [
     {
       "id": "ios_pir_announcement_1",
@@ -391,7 +391,10 @@
       "matchingRules": [
         20
       ],
-      "exclusionRules": []
+      "exclusionRules": [],
+      "displayConditions": {
+        "dismissAfterDaysShown": 5
+      }
     },
     {
       "id": "ios_pir_freemium_scan_complete_results",


### PR DESCRIPTION
Asana task: https://app.asana.com/1/137249556945/task/1216784463593898

Replicates #393 for the freemium PIR entry point RMF.

`ios_pir_freemium_entry_point` re-appears on every new tab page until the user explicitly dismisses it. Add `dismissAfterDaysShown: 5` (mirroring `ios_pir_announcement_1` in #393) so it auto-dismisses 5 days after first display even without interaction.

Bumps iOS remote messaging config version 120 → 121.

Adds min version gating to all freemium RMFs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote messaging JSON only; limits promo persistence and tightens audience to newer app versions with no auth or data-path changes.
> 
> **Overview**
> Bumps iOS remote messaging config **version 120 → 121**.
> 
> For **`ios_pir_freemium_entry_point`** on the new tab page, adds **`displayConditions.dismissAfterDaysShown: 5`** so the promo stops showing five days after it was first displayed, even if the user never dismisses it—same pattern as **`ios_pir_announcement_1`**.
> 
> Adds **`appVersion` min `7.230.0`** to freemium PIR matching rules **20** (entry), **21** (scan with matches), and **22** (scan with no matches) so those RMFs only target builds that support the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc95123dd596fbb6d8930aaff391138b515cc33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->