### PR TITLE
RMF test

### DIFF
--- a/live/macos-config/macos-config.json
+++ b/live/macos-config/macos-config.json
@@ -1,1117 +1,561 @@
 {
-  "version": 59,
+  "version": 60,
   "messages": [
     {
-      "id": "macos_privacy_pro_exit_survey_1",
+      "id": "macos_test_small",
       "content": {
-        "messageType": "big_single_action",
-        "titleText": "Why did you cancel your subscription?",
-        "descriptionText": "Your input helps improve DuckDuckGo for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&ppro_region=us",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [1],
-      "exclusionRules": [5, 7]
+        "messageType": "small",
+        "titleText": "Small",
+        "descriptionText": "Card type 'small'. This type renders no pictogram.",
+        "placeholder": "Announce"
+      }
     },
     {
-      "id": "macos_privacy_pro_exit_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Why did you cancel your subscription?",
-        "descriptionText": "Your input helps improve DuckDuckGo for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [3],
-      "exclusionRules": [5, 7]
-    },
-    {
-      "id": "macos_privacy_pro_exit_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Pourquoi avez-vous annulé votre abonnement DuckDuckGo?",
-        "descriptionText": "En répondant à notre courte enquête, vous contribuerez à l'amélioration de DuckDuckGo pour l'ensemble de nos abonnés.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Lancer l'enquête",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=french&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [13],
-      "exclusionRules": [5, 7]
-    },
-    {
-      "id": "macos_privacy_pro_exit_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Warum haben Sie Ihr DuckDuckGo-Abonnement gekündigt?",
-        "descriptionText": "Durch Teilnahme an unserer kurzen Umfrage helfen Sie uns, DuckDuckGo für alle Abonnenten zu verbessern.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Umfrage starten",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=german&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [14],
-      "exclusionRules": [5, 7]
-    },
-    {
-      "id": "macos_privacy_pro_exit_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Waarom heeft u het DuckDuckGo-abonnement opgezegd?",
-        "descriptionText": "Door deel te nemen aan onze korte enquête, helpt u DuckDuckGo voor alle abonnees te verbeteren.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Enquête starten",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=dutch&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [15],
-      "exclusionRules": [5, 7]
-    },
-    {
-      "id": "macos_privacy_pro_exit_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Dicci perché hai deciso di annullare l’abbonamento a DuckDuckGo",
-        "descriptionText": "Partecipando a questo breve sondaggio, ci aiuterai a migliorare DuckDuckGo per tutti gli utenti abbonati.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Inizia l'indagine",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=italian&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [16],
-      "exclusionRules": [5, 7]
-    },
-    {
-      "id": "macos_privacy_pro_exit_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Cuéntanos por qué dejaste la suscripción a DuckDuckGo",
-        "descriptionText": "Al responder a nuestra breve encuesta, nos ayudarás a mejorar DuckDuckGo para todos los suscriptores.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Empezar encuesta",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3&decLang=spanish_eu&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [17],
-      "exclusionRules": [5, 7]
-    },
-
-
-    {
-      "id": "macos_privacy_pro_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "What do you think of your subscription?",
-        "descriptionText": "Your input helps improve DuckDuckGo for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&ppro_region=us",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [2],
-      "exclusionRules": [5, 6, 8]
-    },
-    {
-      "id": "macos_privacy_pro_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "What do you think of your subscription?",
-        "descriptionText": "Your input helps improve DuckDuckGo for all subscribers.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [4],
-      "exclusionRules": [5, 6, 8]
-    },
-    {
-      "id": "macos_privacy_pro_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Faites-nous part de votre avis sur l’abonnement DuckDuckGo",
-        "descriptionText": "En répondant à notre courte enquête, vous contribuerez à l'amélioration de DuckDuckGo pour l'ensemble de nos abonnés.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Lancer l'enquête",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=french&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [18],
-      "exclusionRules": [5, 6, 8]
-    },
-    {
-      "id": "macos_privacy_pro_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Was halten Sie vom DuckDuckGo-Abonnement?",
-        "descriptionText": "Wenn Sie an unserer kurzen Umfrage teilnehmen, werden wir lhre Eingaben verwenden, um DuckDuckGo für alle Abonnenten zu verbessern.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Umfrage starten",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=german&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [19],
-      "exclusionRules": [5, 6, 8]
-    },
-    {
-      "id": "macos_privacy_pro_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Waar denkt u aan bij het DuckDuckGo-abonnement?",
-        "descriptionText": "Als u onze korte enquête invult, zullen we uw input gebruiken om DuckDuckGo voor alle abonnees te verbeteren.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Enquête starten",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=dutch&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [20],
-      "exclusionRules": [5, 6, 8]
-    },
-    {
-      "id": "macos_privacy_pro_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Cosa ne pensi dell’abbonamento DuckDuckGo?",
-        "descriptionText": "Se completi il nostro breve sondaggio, il tuo contributo aiuterà a migliorare l’esperienza per tutti gli abbonati.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Inizia l'indagine",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=italian&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [21],
-      "exclusionRules": [5, 6, 8]
-    },
-    {
-      "id": "macos_privacy_pro_subscriber_survey_1",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "¿Qué opina del la suscripción a DuckDuckGo?",
-        "descriptionText": "Si completa nuestra breve encuesta, utilizaremos sus comentarios para mejorar DuckDuckGo para todos los suscriptores.",
-        "placeholder": "PrivacyShield",
-        "primaryActionText": "Empezar encuesta",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/240506?list=2&decLang=spanish_eu&ppro_region=row",
-          "additionalParameters": {
-            "queryParams": "var;delta;osv;ddgv;mo;ppro_status;ppro_platform;ppro_billing;ppro_days_since_purchase;ppro_days_until_exp"
-          }
-        }
-      },
-      "matchingRules": [22],
-      "exclusionRules": [5, 6, 8]
-    },
-
-
-    {
-      "id": "macos_permanent_survey_tab_bar",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help Us Improve!",
-        "descriptionText": "We really want to know which features would make our browser better.",
-        "placeholder": "Announce",
-        "primaryActionText": "Tell Us What You Think",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/241004?list=2",
-          "additionalParameters": {
-            "queryParams": "delta;var;osv;ddgv;last_search_state"
-          }
-        }
-      },
-      "matchingRules": [12]
-    },
-    {
-      "id": "macos_critical_update_url",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Updating macOS is recommended",
-        "descriptionText": "Updating to the latest version will fix site loading issues and enhance security.",
-        "placeholder": "CriticalUpdate",
-        "primaryActionText": "How to Update",
-        "primaryAction": {
-          "type": "url",
-          "value": "https://support.apple.com/en-us/108382"
-        }
-      },
-      "translations": {
-        "fr": {
-          "titleText": "La mise à jour de macOS est recommandée",
-          "descriptionText": "La mise à jour vers la dernière version corrige des problèmes de chargement et renforce la sécurité.",
-          "primaryActionText": "Comment mettre à jour"
-        },
-        "de": {
-          "titleText": "macOS-Update empfohlen",
-          "descriptionText": "Mit der neuesten Version beheben Sie Ladefehler und verbessern die Sicherheit.",
-          "primaryActionText": "So aktualisieren Sie"
-        },
-        "nl": {
-          "titleText": "Het wordt aanbevolen macOS bij te werken",
-          "descriptionText": "Door bij te werken naar de nieuwste versie worden laadproblemen opgelost en de beveiliging verbeterd.",
-          "primaryActionText": "Hoe bij te werken"
-        },
-        "it": {
-          "titleText": "Si consiglia di aggiornare macOS",
-          "descriptionText": "Aggiornare all'ultima versione risolverà i problemi di caricamento dei siti e migliorerà la sicurezza.",
-          "primaryActionText": "Come aggiornare"
-        },
-        "es": {
-          "titleText": "Se recomienda actualizar macOS",
-          "descriptionText": "Actualizar a la última versión resolverá problemas de carga de sitios web y mejorará la seguridad.",
-          "primaryActionText": "Cómo actualizar"
-        },
-        "pl": {
-          "titleText": "Zalecana jest aktualizacja systemu macOS",
-          "descriptionText": "Aktualizacja do najnowszej wersji rozwiąże problemy z ładowaniem stron i zwiększy bezpieczeństwo.",
-          "primaryActionText": "Jak zaktualizować"
-        },
-        "ru": {
-          "titleText": "Рекомендуется обновить macOS",
-          "descriptionText": "Обновление до последней версии устранит проблемы с загрузкой сайтов и повысит безопасность.",
-          "primaryActionText": "Как обновить"
-        },
-        "pt": {
-          "titleText": "É recomendável atualizar o macOS",
-          "descriptionText": "A atualização para a versão mais recente corrigirá problemas de carregamento de sites e melhorará a segurança.",
-          "primaryActionText": "Como atualizar"
-        }
-      },
-      "matchingRules": [23],
-      "exclusionRules": []
-    },
-    {
-      "id": "macos_update_app_appstore",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Your DuckDuckGo app is out of date",
-        "descriptionText": "Download the latest version for important fixes and improvements, and to stay up to date.",
-        "placeholder": "AppUpdate",
-        "primaryActionText": "Go to App Store",
-        "primaryAction": {
-          "type": "url",
-          "value": "https://apps.apple.com/us/app/duckduckgo-duck-ai-vpn/id663592361"
-        }
-      },
-      "translations": {
-        "fr": {
-          "titleText": "Votre application DuckDuckGo n'est pas à jour",
-          "descriptionText": "Téléchargez la dernière version pour bénéficier de correctifs et d'améliorations importantes, et rester à jour.",
-          "primaryActionText": "Ouvrir l'App Store"
-        },
-        "de": {
-          "titleText": "Ihre DuckDuckGo-App ist veraltet",
-          "descriptionText": "Laden Sie die neueste Version herunter, um wichtige Fehlerbehebungen und Verbesserungen zu erhalten und auf dem neuesten Stand zu bleiben.",
-          "primaryActionText": "Zum App Store"
-        },
-        "nl": {
-          "titleText": "Uw DuckDuckGo-app is verouderd",
-          "descriptionText": "Download de nieuwste versie voor belangrijke fixes en verbeteringen, en om up-to-date te blijven.",
-          "primaryActionText": "Naar de App Store"
-        },
-        "it": {
-          "titleText": "L'app DuckDuckGo non è aggiornata",
-          "descriptionText": "Scarica la versione più recente per ricevere correzioni e miglioramenti importanti e restare aggiornato.",
-          "primaryActionText": "Vai all'App Store"
-        },
-        "es": {
-          "titleText": "Tu app DuckDuckGo está desactualizada",
-          "descriptionText": "Descarga la última versión para obtener correcciones y mejoras importantes y mantenerte al día.",
-          "primaryActionText": "Ir a la App Store"
-        },
-        "pl": {
-          "titleText": "Twoja aplikacja DuckDuckGo jest nieaktualna",
-          "descriptionText": "Pobierz najnowszą wersję, aby otrzymać ważne poprawki i ulepszenia oraz zachować aktualność.",
-          "primaryActionText": "Przejdź do App Store"
-        },
-        "ru": {
-          "titleText": "Ваше приложение DuckDuckGo устарело",
-          "descriptionText": "Загрузите последнюю версию, чтобы получить важные исправления и улучшения и оставаться на актуальной версии.",
-          "primaryActionText": "Перейти в App Store"
-        },
-        "pt": {
-          "titleText": "A tua aplicação DuckDuckGo está desatualizada",
-          "descriptionText": "Transfere a versão mais recente para obteres correções e melhorias importantes e ficares atualizado.",
-          "primaryActionText": "Ir para a App Store"
-        }
-      },
-      "matchingRules": [27]
-    },
-    {
-      "id": "macos_update_app_sparkle",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Your DuckDuckGo app is out of date",
-        "descriptionText": "Update now to get important fixes and improvements. This will also turn on automatic updates going forward.",
-        "placeholder": "AppUpdate",
-        "primaryActionText": "Update Now",
-        "primaryAction": {
-          "type": "url",
-          "value": "duck://settings/about"
-        }
-      },
-      "translations": {
-        "fr": {
-          "titleText": "Votre application DuckDuckGo n'est pas à jour",
-          "descriptionText": "Mettez à jour maintenant pour bénéficier de correctifs et d'améliorations importantes. Les mises à jour automatiques seront également activées par la suite.",
-          "primaryActionText": "Mettre à jour maintenant"
-        },
-        "de": {
-          "titleText": "Ihre DuckDuckGo-App ist veraltet",
-          "descriptionText": "Aktualisieren Sie jetzt, um wichtige Fehlerbehebungen und Verbesserungen zu erhalten. Dadurch werden künftig auch automatische Updates aktiviert.",
-          "primaryActionText": "Jetzt aktualisieren"
-        },
-        "nl": {
-          "titleText": "Uw DuckDuckGo-app is verouderd",
-          "descriptionText": "Werk nu bij voor belangrijke fixes en verbeteringen. Hierdoor worden voortaan ook automatische updates ingeschakeld.",
-          "primaryActionText": "Nu bijwerken"
-        },
-        "it": {
-          "titleText": "L'app DuckDuckGo non è aggiornata",
-          "descriptionText": "Aggiorna ora per ottenere correzioni e miglioramenti importanti. Così facendo verranno attivati anche gli aggiornamenti automatici.",
-          "primaryActionText": "Aggiorna ora"
-        },
-        "es": {
-          "titleText": "Tu app DuckDuckGo está desactualizada",
-          "descriptionText": "Actualiza ahora para obtener correcciones y mejoras importantes. Esto también activará las actualizaciones automáticas a partir de ahora.",
-          "primaryActionText": "Actualizar ahora"
-        },
-        "pl": {
-          "titleText": "Twoja aplikacja DuckDuckGo jest nieaktualna",
-          "descriptionText": "Zaktualizuj teraz, aby otrzymać ważne poprawki i ulepszenia. Włączy to również automatyczne aktualizacje w przyszłości.",
-          "primaryActionText": "Zaktualizuj teraz"
-        },
-        "ru": {
-          "titleText": "Ваше приложение DuckDuckGo устарело",
-          "descriptionText": "Обновите сейчас, чтобы получить важные исправления и улучшения. Это также включит автоматические обновления в дальнейшем.",
-          "primaryActionText": "Обновить сейчас"
-        },
-        "pt": {
-          "titleText": "A tua aplicação DuckDuckGo está desatualizada",
-          "descriptionText": "Atualiza agora para obteres correções e melhorias importantes. Isto também ativará as atualizações automáticas a partir de agora.",
-          "primaryActionText": "Atualizar agora"
-        }
-      },
-      "matchingRules": [28]
-    },
-    {
-      "id": "macos_big_sur_eos_update_cta",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Big Sur support has ended",
-        "descriptionText": "Update macOS to Monterey or later to keep getting new DuckDuckGo features, fixes, and security improvements.",
-        "placeholder": "VeryCriticalUpdate",
-        "primaryActionText": "Update macOS",
-        "primaryAction": {
-          "type": "navigation",
-          "value": "softwareUpdate"
-        }
-      },
-      "translations": {
-        "fr": {
-          "titleText": "La prise en charge de Big Sur est terminée",
-          "descriptionText": "Mettez à jour macOS vers Monterey ou une version ultérieure pour continuer à bénéficier des nouvelles fonctionnalités, corrections et améliorations de sécurité de DuckDuckGo.",
-          "primaryActionText": "Mettre à jour macOS"
-        },
-        "de": {
-          "titleText": "Der Support für Big Sur ist eingestellt",
-          "descriptionText": "Aktualisieren Sie macOS auf Monterey oder neuer, um weiterhin neue DuckDuckGo-Funktionen, Fehlerbehebungen und Sicherheitsverbesserungen zu erhalten.",
-          "primaryActionText": "macOS aktualisieren"
-        },
-        "nl": {
-          "titleText": "De ondersteuning voor Big Sur is beëindigd",
-          "descriptionText": "Werk macOS bij naar Monterey of nieuwer om nieuwe DuckDuckGo-functies, oplossingen en beveiligingsverbeteringen te blijven ontvangen.",
-          "primaryActionText": "macOS bijwerken"
-        },
-        "it": {
-          "titleText": "Il supporto per Big Sur è terminato",
-          "descriptionText": "Aggiorna macOS a Monterey o versioni successive per continuare a ricevere nuove funzionalità, correzioni e miglioramenti della sicurezza di DuckDuckGo.",
-          "primaryActionText": "Aggiorna macOS"
-        },
-        "es": {
-          "titleText": "El soporte para Big Sur ha finalizado",
-          "descriptionText": "Actualiza macOS a Monterey o una versión posterior para seguir recibiendo nuevas funciones, correcciones y mejoras de seguridad de DuckDuckGo.",
-          "primaryActionText": "Actualizar macOS"
-        },
-        "pl": {
-          "titleText": "Wsparcie dla Big Sur zostało zakończone",
-          "descriptionText": "Zaktualizuj macOS do wersji Monterey lub nowszej, aby nadal otrzymywać nowe funkcje, poprawki i ulepszenia zabezpieczeń DuckDuckGo.",
-          "primaryActionText": "Zaktualizuj macOS"
-        },
-        "ru": {
-          "titleText": "Поддержка Big Sur прекращена",
-          "descriptionText": "Обновите macOS до Monterey или более новой версии, чтобы продолжать получать новые функции, исправления и улучшения безопасности DuckDuckGo.",
-          "primaryActionText": "Обновить macOS"
-        },
-        "pt": {
-          "titleText": "O suporte ao Big Sur foi encerrado",
-          "descriptionText": "Atualiza o macOS para o Monterey ou posterior para continuares a receber novas funcionalidades, correções e melhorias de segurança do DuckDuckGo.",
-          "primaryActionText": "Atualizar macOS"
-        }
-      },
-      "matchingRules": [29]
-    },
-    {
-      "id": "macos_big_sur_eos_no_cta",
+      "id": "macos_test_medium_announce",
       "content": {
         "messageType": "medium",
-        "titleText": "Big Sur support has ended",
-        "descriptionText": "DuckDuckGo updates have ended for macOS Big Sur. Your browser will keep working as it does today.",
-        "placeholder": "VeryCriticalUpdate"
-      },
-      "translations": {
-        "fr": {
-          "titleText": "La prise en charge de Big Sur est terminée",
-          "descriptionText": "Les mises à jour de DuckDuckGo sont terminées pour macOS Big Sur. Votre navigateur continuera de fonctionner comme aujourd'hui."
-        },
-        "de": {
-          "titleText": "Der Support für Big Sur ist eingestellt",
-          "descriptionText": "Die DuckDuckGo-Updates für macOS Big Sur wurden eingestellt. Ihr Browser funktioniert weiterhin wie bisher."
-        },
-        "nl": {
-          "titleText": "De ondersteuning voor Big Sur is beëindigd",
-          "descriptionText": "De DuckDuckGo-updates voor macOS Big Sur zijn beëindigd. Uw browser blijft werken zoals nu."
-        },
-        "it": {
-          "titleText": "Il supporto per Big Sur è terminato",
-          "descriptionText": "Gli aggiornamenti di DuckDuckGo per macOS Big Sur sono terminati. Il tuo browser continuerà a funzionare come oggi."
-        },
-        "es": {
-          "titleText": "El soporte para Big Sur ha finalizado",
-          "descriptionText": "Las actualizaciones de DuckDuckGo para macOS Big Sur han finalizado. Tu navegador seguirá funcionando como hasta ahora."
-        },
-        "pl": {
-          "titleText": "Wsparcie dla Big Sur zostało zakończone",
-          "descriptionText": "Aktualizacje DuckDuckGo dla macOS Big Sur zostały zakończone. Twoja przeglądarka będzie nadal działać tak jak obecnie."
-        },
-        "ru": {
-          "titleText": "Поддержка Big Sur прекращена",
-          "descriptionText": "Обновления DuckDuckGo для macOS Big Sur прекращены. Ваш браузер продолжит работать так же, как сегодня."
-        },
-        "pt": {
-          "titleText": "O suporte ao Big Sur foi encerrado",
-          "descriptionText": "As atualizações do DuckDuckGo para o macOS Big Sur foram encerradas. O teu navegador continuará a funcionar como hoje."
-        }
-      },
-      "matchingRules": [30]
+        "titleText": "Announce × Medium",
+        "descriptionText": "Card type 'medium' with the Announce pictogram.",
+        "placeholder": "Announce"
+      }
     },
     {
-      "id": "macos_big_sur_eos_update_cta_legacy",
+      "id": "macos_test_big_single_action_announce",
       "content": {
         "messageType": "big_single_action",
-        "titleText": "Big Sur support has ended",
-        "descriptionText": "Update macOS to Monterey or later to keep getting new DuckDuckGo features, fixes, and security improvements.",
-        "placeholder": "VeryCriticalUpdate",
-        "primaryActionText": "Update macOS",
+        "titleText": "Announce × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the Announce pictogram.",
+        "placeholder": "Announce",
+        "primaryActionText": "Dismiss",
         "primaryAction": {
-          "type": "navigation",
-          "value": "softwareUpdate"
+          "type": "dismiss",
+          "value": ""
         }
-      },
-      "translations": {
-        "fr": {
-          "titleText": "La prise en charge de Big Sur est terminée",
-          "descriptionText": "Mettez à jour macOS vers Monterey ou une version ultérieure pour continuer à bénéficier des nouvelles fonctionnalités, corrections et améliorations de sécurité de DuckDuckGo.",
-          "primaryActionText": "Mettre à jour macOS"
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_announce",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "Announce × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the Announce pictogram.",
+        "placeholder": "Announce",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
         },
-        "de": {
-          "titleText": "Der Support für Big Sur ist eingestellt",
-          "descriptionText": "Aktualisieren Sie macOS auf Monterey oder neuer, um weiterhin neue DuckDuckGo-Funktionen, Fehlerbehebungen und Sicherheitsverbesserungen zu erhalten.",
-          "primaryActionText": "macOS aktualisieren"
-        },
-        "nl": {
-          "titleText": "De ondersteuning voor Big Sur is beëindigd",
-          "descriptionText": "Werk macOS bij naar Monterey of nieuwer om nieuwe DuckDuckGo-functies, oplossingen en beveiligingsverbeteringen te blijven ontvangen.",
-          "primaryActionText": "macOS bijwerken"
-        },
-        "it": {
-          "titleText": "Il supporto per Big Sur è terminato",
-          "descriptionText": "Aggiorna macOS a Monterey o versioni successive per continuare a ricevere nuove funzionalità, correzioni e miglioramenti della sicurezza di DuckDuckGo.",
-          "primaryActionText": "Aggiorna macOS"
-        },
-        "es": {
-          "titleText": "El soporte para Big Sur ha finalizado",
-          "descriptionText": "Actualiza macOS a Monterey o una versión posterior para seguir recibiendo nuevas funciones, correcciones y mejoras de seguridad de DuckDuckGo.",
-          "primaryActionText": "Actualizar macOS"
-        },
-        "pl": {
-          "titleText": "Wsparcie dla Big Sur zostało zakończone",
-          "descriptionText": "Zaktualizuj macOS do wersji Monterey lub nowszej, aby nadal otrzymywać nowe funkcje, poprawki i ulepszenia zabezpieczeń DuckDuckGo.",
-          "primaryActionText": "Zaktualizuj macOS"
-        },
-        "ru": {
-          "titleText": "Поддержка Big Sur прекращена",
-          "descriptionText": "Обновите macOS до Monterey или более новой версии, чтобы продолжать получать новые функции, исправления и улучшения безопасности DuckDuckGo.",
-          "primaryActionText": "Обновить macOS"
-        },
-        "pt": {
-          "titleText": "O suporte ao Big Sur foi encerrado",
-          "descriptionText": "Atualiza o macOS para o Monterey ou posterior para continuares a receber novas funcionalidades, correções e melhorias de segurança do DuckDuckGo.",
-          "primaryActionText": "Atualizar macOS"
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
         }
-      },
-      "matchingRules": [31]
+      }
+    },
+    {
+      "id": "macos_test_medium_ddgannounce",
+      "content": {
+        "messageType": "medium",
+        "titleText": "DDGAnnounce × Medium",
+        "descriptionText": "Card type 'medium' with the DDGAnnounce pictogram.",
+        "placeholder": "DDGAnnounce"
+      }
+    },
+    {
+      "id": "macos_test_big_single_action_ddgannounce",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "DDGAnnounce × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the DDGAnnounce pictogram.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_ddgannounce",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "DDGAnnounce × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the DDGAnnounce pictogram.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_medium_criticalupdate",
+      "content": {
+        "messageType": "medium",
+        "titleText": "CriticalUpdate × Medium",
+        "descriptionText": "Card type 'medium' with the CriticalUpdate pictogram.",
+        "placeholder": "CriticalUpdate"
+      }
+    },
+    {
+      "id": "macos_test_big_single_action_criticalupdate",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "CriticalUpdate × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the CriticalUpdate pictogram.",
+        "placeholder": "CriticalUpdate",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_criticalupdate",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "CriticalUpdate × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the CriticalUpdate pictogram.",
+        "placeholder": "CriticalUpdate",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_medium_appupdate",
+      "content": {
+        "messageType": "medium",
+        "titleText": "AppUpdate × Medium",
+        "descriptionText": "Card type 'medium' with the AppUpdate pictogram.",
+        "placeholder": "AppUpdate"
+      }
+    },
+    {
+      "id": "macos_test_big_single_action_appupdate",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "AppUpdate × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the AppUpdate pictogram.",
+        "placeholder": "AppUpdate",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_appupdate",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "AppUpdate × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the AppUpdate pictogram.",
+        "placeholder": "AppUpdate",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_medium_duck_ai",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Duck.ai × Medium",
+        "descriptionText": "Card type 'medium' with the Duck.ai pictogram.",
+        "placeholder": "Duck.ai"
+      }
+    },
+    {
+      "id": "macos_test_big_single_action_duck_ai",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Duck.ai × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the Duck.ai pictogram.",
+        "placeholder": "Duck.ai",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_duck_ai",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "Duck.ai × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the Duck.ai pictogram.",
+        "placeholder": "Duck.ai",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_medium_privacyshield",
+      "content": {
+        "messageType": "medium",
+        "titleText": "PrivacyShield × Medium",
+        "descriptionText": "Card type 'medium' with the PrivacyShield pictogram.",
+        "placeholder": "PrivacyShield"
+      }
+    },
+    {
+      "id": "macos_test_big_single_action_privacyshield",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "PrivacyShield × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the PrivacyShield pictogram.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_privacyshield",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "PrivacyShield × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the PrivacyShield pictogram.",
+        "placeholder": "PrivacyShield",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_medium_radar",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Radar × Medium",
+        "descriptionText": "Card type 'medium' with the Radar pictogram.",
+        "placeholder": "Radar"
+      }
+    },
+    {
+      "id": "macos_test_big_single_action_radar",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Radar × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the Radar pictogram.",
+        "placeholder": "Radar",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_radar",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "Radar × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the Radar pictogram.",
+        "placeholder": "Radar",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_medium_radarcheckgreen",
+      "content": {
+        "messageType": "medium",
+        "titleText": "RadarCheckGreen × Medium",
+        "descriptionText": "Card type 'medium' with the RadarCheckGreen pictogram.",
+        "placeholder": "RadarCheckGreen"
+      }
+    },
+    {
+      "id": "macos_test_big_single_action_radarcheckgreen",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "RadarCheckGreen × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the RadarCheckGreen pictogram.",
+        "placeholder": "RadarCheckGreen",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_radarcheckgreen",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "RadarCheckGreen × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the RadarCheckGreen pictogram.",
+        "placeholder": "RadarCheckGreen",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_medium_radarcheckpurple",
+      "content": {
+        "messageType": "medium",
+        "titleText": "RadarCheckPurple × Medium",
+        "descriptionText": "Card type 'medium' with the RadarCheckPurple pictogram.",
+        "placeholder": "RadarCheckPurple"
+      }
+    },
+    {
+      "id": "macos_test_big_single_action_radarcheckpurple",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "RadarCheckPurple × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the RadarCheckPurple pictogram.",
+        "placeholder": "RadarCheckPurple",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_radarcheckpurple",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "RadarCheckPurple × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the RadarCheckPurple pictogram.",
+        "placeholder": "RadarCheckPurple",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_medium_pir",
+      "content": {
+        "messageType": "medium",
+        "titleText": "PIR × Medium",
+        "descriptionText": "Card type 'medium' with the PIR pictogram.",
+        "placeholder": "PIR"
+      }
+    },
+    {
+      "id": "macos_test_big_single_action_pir",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "PIR × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the PIR pictogram.",
+        "placeholder": "PIR",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_pir",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "PIR × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the PIR pictogram.",
+        "placeholder": "PIR",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_medium_subscription",
+      "content": {
+        "messageType": "medium",
+        "titleText": "Subscription × Medium",
+        "descriptionText": "Card type 'medium' with the Subscription pictogram.",
+        "placeholder": "Subscription"
+      }
+    },
+    {
+      "id": "macos_test_big_single_action_subscription",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Subscription × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the Subscription pictogram.",
+        "placeholder": "Subscription",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_subscription",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "Subscription × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the Subscription pictogram.",
+        "placeholder": "Subscription",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_medium_verycriticalupdate",
+      "content": {
+        "messageType": "medium",
+        "titleText": "VeryCriticalUpdate × Medium",
+        "descriptionText": "Card type 'medium' with the VeryCriticalUpdate pictogram.",
+        "placeholder": "VeryCriticalUpdate"
+      }
+    },
+    {
+      "id": "macos_test_big_single_action_verycriticalupdate",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "VeryCriticalUpdate × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the VeryCriticalUpdate pictogram.",
+        "placeholder": "VeryCriticalUpdate",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_verycriticalupdate",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "VeryCriticalUpdate × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the VeryCriticalUpdate pictogram.",
+        "placeholder": "VeryCriticalUpdate",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_medium_youtubenew",
+      "content": {
+        "messageType": "medium",
+        "titleText": "YoutubeNew × Medium",
+        "descriptionText": "Card type 'medium' with the YoutubeNew pictogram.",
+        "placeholder": "YoutubeNew"
+      }
+    },
+    {
+      "id": "macos_test_big_single_action_youtubenew",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "YoutubeNew × Big, Single Action",
+        "descriptionText": "Card type 'big_single_action' with the YoutubeNew pictogram.",
+        "placeholder": "YoutubeNew",
+        "primaryActionText": "Dismiss",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
+    },
+    {
+      "id": "macos_test_big_two_action_youtubenew",
+      "content": {
+        "messageType": "big_two_action",
+        "titleText": "YoutubeNew × Big, Two Actions",
+        "descriptionText": "Card type 'big_two_action' with the YoutubeNew pictogram.",
+        "placeholder": "YoutubeNew",
+        "primaryActionText": "Primary",
+        "primaryAction": {
+          "type": "dismiss",
+          "value": ""
+        },
+        "secondaryActionText": "Secondary",
+        "secondaryAction": {
+          "type": "dismiss",
+          "value": ""
+        }
+      }
     }
   ],
-  "rules": [
-    {
-      "id": 1,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["expiring", "expired"]
-        },
-        "pproDaysUntilExpiryOrRenewal": {
-          "max": 10
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": ["en-US"]
-        }
-      }
-    },
-    {
-      "id": 2,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproDaysSinceSubscribed": {
-          "min": 14
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["active"]
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": ["en-US"]
-        }
-      }
-    },
-    {
-      "id": 3,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["expiring", "expired"]
-        },
-        "pproDaysUntilExpiryOrRenewal": {
-          "max": 10
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": ["en-CA", "en-GB"]
-        }
-      }
-    },
-    {
-      "id": 4,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproDaysSinceSubscribed": {
-          "min": 14
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["active"]
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": ["en-CA", "en-GB"]
-        }
-      }
-    },
-    {
-      "id": 5,
-      "attributes": {
-        "interactedWithMessage": {
-          "value": [
-            "macos_privacy_pro_exit_survey_1",
-            "macos_privacy_pro_sparkle_exit_survey_1",
-            "macos_privacy_pro_app_store_exit_survey_1"
-          ]
-        }
-      }
-    },
-    {
-      "id": 6,
-      "attributes": {
-        "interactedWithMessage": {
-          "value": [
-            "macos_privacy_pro_subscriber_survey_1",
-            "macos_privacy_pro_sparkle_subscriber_survey_1",
-            "macos_privacy_pro_app_store_subscriber_survey_1"
-          ]
-        }
-      }
-    },
-    {
-      "id": 7,
-      "attributes": {
-        "interactedWithDeprecatedMacRemoteMessage": {
-          "value": ["privacy_pro_exit_survey_1"]
-        }
-      }
-    },
-    {
-      "id": 8,
-      "attributes": {
-        "interactedWithDeprecatedMacRemoteMessage": {
-          "value": ["privacy_pro_survey_1"]
-        }
-      }
-    },
-    {
-      "id": 12,
-      "attributes": {
-        "appVersion": {
-          "min": "1.121.0"
-        },
-        "daysSinceInstalled": {
-          "min": 14,
-          "max": 21
-        },
-        "locale": {
-          "value": [
-            "en-US",
-            "en-CA",
-            "en-GB",
-            "en-AU"
-          ]
-        }
-      }
-    },
-
-
-
-    {
-      "id": 13,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["expiring", "expired"]
-        },
-        "pproDaysUntilExpiryOrRenewal": {
-          "max": 10
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": [
-            "fr-FR",
-            "fr-CA",
-            "fr-BE",
-            "fr-CH"
-          ]
-        }
-      }
-    },
-    {
-      "id": 14,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["expiring", "expired"]
-        },
-        "pproDaysUntilExpiryOrRenewal": {
-          "max": 10
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": [
-            "de-DE",
-            "de-AT",
-            "de-CH"
-          ]
-        }
-      }
-    },
-    {
-      "id": 15,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["expiring", "expired"]
-        },
-        "pproDaysUntilExpiryOrRenewal": {
-          "max": 10
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": [
-            "nl-NL",
-            "nl-BE"
-          ]
-        }
-      }
-    },
-    {
-      "id": 16,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["expiring", "expired"]
-        },
-        "pproDaysUntilExpiryOrRenewal": {
-          "max": 10
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": [
-            "it-IT"
-          ]
-        }
-      }
-    },
-    {
-      "id": 17,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["expiring", "expired"]
-        },
-        "pproDaysUntilExpiryOrRenewal": {
-          "max": 10
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": [
-            "es-ES"
-          ]
-        }
-      }
-    },
-    {
-      "id": 18,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproDaysSinceSubscribed": {
-          "min": 14
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["active"]
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": [
-            "fr-FR",
-            "fr-CA",
-            "fr-BE",
-            "fr-CH"
-          ]
-        }
-      }
-    },
-    {
-      "id": 19,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproDaysSinceSubscribed": {
-          "min": 14
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["active"]
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": [
-            "de-DE",
-            "de-AT",
-            "de-CH"
-          ]
-        }
-      }
-    },
-    {
-      "id": 20,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproDaysSinceSubscribed": {
-          "min": 14
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["active"]
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": [
-            "nl-NL",
-            "nl-BE"
-          ]
-        }
-      }
-    },
-    {
-      "id": 21,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproDaysSinceSubscribed": {
-          "min": 14
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["active"]
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": [
-            "it-IT"
-          ]
-        }
-      }
-    },
-    {
-      "id": 22,
-      "attributes": {
-        "pproSubscriber": {
-          "value": true
-        },
-        "pproDaysSinceSubscribed": {
-          "min": 14
-        },
-        "pproPurchasePlatform": {
-          "value": ["apple", "stripe"]
-        },
-        "pproSubscriptionStatus": {
-          "value": ["active"]
-        },
-        "appVersion": {
-          "min": "1.101.0"
-        },
-        "locale": {
-          "value": [
-            "es-ES"
-          ]
-        }
-      }
-    },
-    {
-      "id": 23,
-      "attributes": {
-        "appVersion": {
-          "max": "1.179.0"
-        },
-        "osApi": {
-          "max": "14.999.999"
-        }
-      }
-    },
-    {
-      "id": 27,
-      "attributes": {
-        "appVersion": {
-          "max": "1.182.0"
-        },
-        "installedMacAppStore": {
-          "value": true
-        }
-      }
-    },
-    {
-      "id": 28,
-      "attributes": {
-        "appVersion": {
-          "max": "1.182.0"
-        },
-        "installedMacAppStore": {
-          "value": false
-        }
-      }
-    },
-    {
-      "id": 29,
-      "attributes": {
-        "appVersion": {
-          "min": "1.193.0"
-        },
-        "osApi": {
-          "min": "11.0.0",
-          "max": "11.999.999"
-        },
-        "canUpgradeOS": {
-          "value": true
-        }
-      }
-    },
-    {
-      "id": 30,
-      "attributes": {
-        "appVersion": {
-          "min": "1.193.0"
-        },
-        "osApi": {
-          "min": "11.0.0",
-          "max": "11.999.999"
-        },
-        "canUpgradeOS": {
-          "value": false
-        }
-      }
-    },
-    {
-      "id": 31,
-      "attributes": {
-        "appVersion": {
-          "max": "1.192.999"
-        },
-        "osApi": {
-          "min": "11.0.0",
-          "max": "11.999.999"
-        }
-      }
-    }
-  ]
+  "rules": []
 }


### PR DESCRIPTION
Tests each pictogram × message type.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> If published to production, users would lose all real remote messages and targeting; only safe as a staging/QA config that must not merge to main unchanged.
> 
> **Overview**
> **Replaces** the production macOS remote messaging payload in `macos-config.json` (version **59 → 60**) with a **QA matrix** of `macos_test_*` messages that exercise each **pictogram** (`placeholder`) against **small**, **medium**, **big_single_action**, and **big_two_action** layouts, using **dismiss-only** actions.
> 
> **Removes** all prior live campaigns (Privacy Pro surveys, app/OS update prompts, Big Sur end-of-support, tab-bar survey, locales/translations) and **clears** `rules` (was dozens of targeting rules), so nothing is gated by subscriber/locale/version attributes anymore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e452cb28918f9f45ccbae6229cb99eb4755522e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->