### PR TITLE
Deprecate x86 message for windows.

### DIFF
--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 66,
+  "version": 67,
   "messages": [
     {
       "id": "windows_privacy_pro_exit_survey_1",
@@ -74,6 +74,24 @@
         11,
         14
       ]
+    },
+    {
+      "id": "windows_deprecate_x86_1",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "x86 Support is Ending",
+        "descriptionText": "With version number 0.169.0 we're ending support for x86 architecture.",
+        "placeholder": "DDGAnnounce",
+        "primaryActionText": "Learn more",
+        "primaryAction": {
+          "type": "url",
+          "value": "https://duckduckgo.com/duckduckgo-help-pages/get-duckduckgo/get-duckduckgo-browser-on-windows#ending-support-for-x86"
+        }
+      },
+      "matchingRules": [
+        15
+      ],
+      "exclusionRules": []
     }
   ],
   "rules": [
@@ -202,6 +220,14 @@
       "attributes": {
         "interactedWithMessage": {
           "value": [ "windows_onboarding_v4_survey" ]
+        }
+      }
+    },
+    {
+      "id": 15,
+      "attributes": {
+        "osArch": {
+          "value": "X86"
         }
       }
     }

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -81,7 +81,7 @@
         "messageType": "big_single_action",
         "titleText": "x86 Support is Ending",
         "descriptionText": "With version number 0.169.0 we're ending support for x86 architecture.",
-        "placeholder": "DDGAnnounce",
+        "placeholder": "CriticalUpdate",
         "primaryActionText": "Learn more",
         "primaryAction": {
           "type": "url",

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -80,7 +80,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "x86 Support is Ending",
-        "descriptionText": "With version number 0.169.0 we're ending support for x86 architecture.",
+        "descriptionText": "With version number 0.169.0 we're ending support for x86 architecture. To continue receiving updates, you'll have to install the x64 version of Windows 10, or upgrade to Windows 11.",
         "placeholder": "CriticalUpdate",
         "primaryActionText": "Learn more",
         "primaryAction": {

--- a/live/windows-config/windows-config.json
+++ b/live/windows-config/windows-config.json
@@ -80,7 +80,7 @@
       "content": {
         "messageType": "big_single_action",
         "titleText": "x86 Support is Ending",
-        "descriptionText": "With version number 0.169.0 we're ending support for x86 architecture. To continue receiving updates, you'll have to install the x64 version of Windows 10, or upgrade to Windows 11.",
+        "descriptionText": "With version number 0.170.0 we're ending support for x86 architecture. To continue receiving updates, you'll have to install the x64 version of Windows 10, or upgrade to Windows 11.",
         "placeholder": "CriticalUpdate",
         "primaryActionText": "Learn more",
         "primaryAction": {


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1207619243206445/task/1216840915794814 - this message shows a warning to users about x86 support being deprecated for windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only remote messaging change with no application logic; low blast radius aside from which users see the notice.
> 
> **Overview**
> Adds a new remote **CriticalUpdate** in-app message (`windows_deprecate_x86_1`) for Windows users on **x86**, warning that support ends with browser **0.170.0** and pointing them to install x64 on Windows 10 or upgrade to Windows 11.
> 
> Bumps `windows-config` **version** to **67** and introduces matching **rule 15** (`osArch` = `X86`) with no exclusion rules on this message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7440893805041470316871bee460b8bdb98a0793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->