### PR TITLE
[TEST - DO NOT MERGE] Android: Add post-onboarding announcement message

### DIFF
--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 111,
+  "version": 112,
   "messages": [
     {
       "id": "android_ntp_after_idle_existing_users_without_hatch_2026",
@@ -909,6 +909,21 @@
         }
       },
       "surfaces": ["new_tab_page"]
+    },
+    {
+      "id": "android_post_onboarding_announcement",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Test: Post-Onboarding Message",
+        "descriptionText": "This is a test message shown right after onboarding. It stays visible until dismissed.",
+        "placeholder": "Announce",
+        "primaryActionText": "Got It",
+        "primaryAction": {
+          "type": "dismiss"
+        }
+      },
+      "matchingRules": [33],
+      "exclusionRules": []
     }
   ],
   "rules": [
@@ -1510,6 +1525,14 @@
       "attributes": {
         "fireModeUsed": {
           "value": true
+        }
+      }
+    },
+    {
+      "id": 33,
+      "attributes": {
+        "daysSinceInstalled": {
+          "min": 0
         }
       }
     }

--- a/live/android-config/android-config.json
+++ b/live/android-config/android-config.json
@@ -2,6 +2,21 @@
   "version": 112,
   "messages": [
     {
+      "id": "android_post_onboarding_announcement",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Test: Post-Onboarding Message",
+        "descriptionText": "This is a test message shown right after onboarding. It stays visible until dismissed.",
+        "placeholder": "Announce",
+        "primaryActionText": "Got It",
+        "primaryAction": {
+          "type": "dismiss"
+        }
+      },
+      "matchingRules": [33],
+      "exclusionRules": []
+    },
+    {
       "id": "android_ntp_after_idle_existing_users_without_hatch_2026",
       "content": {
         "messageType": "big_two_action",
@@ -909,21 +924,6 @@
         }
       },
       "surfaces": ["new_tab_page"]
-    },
-    {
-      "id": "android_post_onboarding_announcement",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Test: Post-Onboarding Message",
-        "descriptionText": "This is a test message shown right after onboarding. It stays visible until dismissed.",
-        "placeholder": "Announce",
-        "primaryActionText": "Got It",
-        "primaryAction": {
-          "type": "dismiss"
-        }
-      },
-      "matchingRules": [33],
-      "exclusionRules": []
     }
   ],
   "rules": [


### PR DESCRIPTION
Testing only, not intended to be merged.

Adds android_post_onboarding_announcement, shown immediately after onboarding completes and persistent until dismissed. Matching rule 33 (daysSinceInstalled min 0) matches all users.