### PR TITLE
iOS: Set freemium PIR RMF entry point to 3%

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 124,
+  "version": 125,
   "messages": [
     {
       "id": "ios_pir_announcement_1",
@@ -889,7 +889,7 @@
     {
       "id": 20,
       "targetPercentile": {
-        "before": 0
+        "before": 0.03
       },
       "attributes": {
         "appVersion": {


### PR DESCRIPTION
## Asana task
https://app.asana.com/1/137249556945/project/1210594645229050/task/1216592974254601

## What

Updates `targetPercentile: { before: 0.03 }` on matching rule `20` (used by the `ios_pir_freemium_entry_point` message) and bumps the iOS config version `124 → 125`.

## Why

Per the [rollout plan](https://app.asana.com/1/137249556945/project/1203581873609357/task/1215530017305256?focus=true) we are ramping this message up to 3%.

## Scope

- Only rule `20` (the entry point) is changed.
- Scan-complete follow-up messages (rules `21` / `22`) are intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only rollout percentage for an existing RMF message; no app logic or other rules modified.
> 
> **Overview**
> Bumps iOS remote messaging config **124 → 125** and widens rollout of the **freemium PIR new-tab entry** (`ios_pir_freemium_entry_point`) by changing matching rule **20**’s `targetPercentile.before` from **0** to **0.03** (3% of eligible users). Scan-complete follow-up rules **21** and **22** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 404ba5497731819c4c0db4f835494c0a7c75ea4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->