### PR TITLE
iOS: Set freemium PIR RMF entry point to 5%

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 125,
+  "version": 126,
   "messages": [
     {
       "id": "ios_pir_announcement_1",
@@ -889,7 +889,7 @@
     {
       "id": 20,
       "targetPercentile": {
-        "before": 0.03
+        "before": 0.05
       },
       "attributes": {
         "appVersion": {


### PR DESCRIPTION
## Asana task
https://app.asana.com/1/137249556945/project/1210594645229050/task/1216592974254602?focus=true

## What

Updates `targetPercentile: { before: 0.05 }` on matching rule `20` (used by the `ios_pir_freemium_entry_point` message) and bumps the iOS config version `125 → 126`.

## Why

Per the [rollout plan](https://app.asana.com/1/137249556945/project/1203581873609357/task/1215530017305256?focus=true) we are ramping this message up to 5%.

## Scope

- Only rule `20` (the entry point) is changed.
- Scan-complete follow-up messages (rules `21` / `22`) are intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only rollout tweak for a single RMF message; no app logic or other rules changed.
> 
> **Overview**
> Bumps the iOS RMF config **version** from `125` to `126` and widens rollout for the freemium Personal Information Removal new-tab entry point.
> 
> On matching rule **20** (used by `ios_pir_freemium_entry_point`), `targetPercentile.before` changes from **0.03** to **0.05**, so more eligible users see the “Start Free Scan” message. Scan-complete messages tied to rules **21** and **22** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eedf65ebf7a87cddd7c9c2489a33c2f9eb01554. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->