### PR TITLE
iOS/macOS: Update samples

### DIFF
--- a/samples/ios/sample-survey.json
+++ b/samples/ios/sample-survey.json
@@ -1,0 +1,63 @@
+{
+  "version": 0,
+  "messages": [
+    {
+      "id": "survey-with-duck-ai-usage",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve Duck.ai",
+        "descriptionText": "Share your feedback about your experience with Duck.ai.",
+        "placeholder": "Announce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://duckduckgo.com/survey",
+          "additionalParameters": {
+            "queryParams": "atb;var;delta;osv;ddgv;last_duck_ai_usage"
+          }
+        }
+      },
+      "matchingRules": [],
+      "exclusionRules": []
+    },
+    {
+      "id": "survey-with-standard-parameters",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve DuckDuckGo",
+        "descriptionText": "Share your feedback about your experience with DuckDuckGo.",
+        "placeholder": "Announce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://duckduckgo.com/survey",
+          "additionalParameters": {
+            "queryParams": "atb;var;delta;osv;ddgv"
+          }
+        }
+      },
+      "matchingRules": [],
+      "exclusionRules": []
+    },
+    {
+      "id": "survey-with-search-and-duck-ai-usage",
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Tell Us About Your Search Experience",
+        "descriptionText": "Share your feedback about using Search and Duck.ai.",
+        "placeholder": "Announce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://duckduckgo.com/survey",
+          "additionalParameters": {
+            "queryParams": "atb;var;delta;osv;ddgv;last_search_state;last_duck_ai_usage"
+          }
+        }
+      },
+      "matchingRules": [],
+      "exclusionRules": []
+    }
+  ],
+  "rules": []
+}

--- a/samples/ios/sample-survey.json
+++ b/samples/ios/sample-survey.json
@@ -2,7 +2,32 @@
   "version": 0,
   "messages": [
     {
+      "id": "survey-with-basic-parameters",
+      "surfaces": [
+        "new_tab_page"
+      ],
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve DuckDuckGo",
+        "descriptionText": "Share your feedback about your experience with DuckDuckGo.",
+        "placeholder": "Announce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://example.com/survey",
+          "additionalParameters": {
+            "queryParams": "atb;var;delta;osv;ddgv;mo;locale"
+          }
+        }
+      },
+      "matchingRules": [],
+      "exclusionRules": []
+    },
+    {
       "id": "survey-with-duck-ai-usage",
+      "surfaces": [
+        "new_tab_page"
+      ],
       "content": {
         "messageType": "big_single_action",
         "titleText": "Help Us Improve Duck.ai",
@@ -21,26 +46,10 @@
       "exclusionRules": []
     },
     {
-      "id": "survey-with-standard-parameters",
-      "content": {
-        "messageType": "big_single_action",
-        "titleText": "Help Us Improve DuckDuckGo",
-        "descriptionText": "Share your feedback about your experience with DuckDuckGo.",
-        "placeholder": "Announce",
-        "primaryActionText": "Take Survey",
-        "primaryAction": {
-          "type": "survey",
-          "value": "https://example.com/survey",
-          "additionalParameters": {
-            "queryParams": "atb;var;delta;osv;ddgv"
-          }
-        }
-      },
-      "matchingRules": [],
-      "exclusionRules": []
-    },
-    {
       "id": "survey-with-search-and-duck-ai-usage",
+      "surfaces": [
+        "new_tab_page"
+      ],
       "content": {
         "messageType": "big_single_action",
         "titleText": "Tell Us About Your Search Experience",

--- a/samples/ios/sample-survey.json
+++ b/samples/ios/sample-survey.json
@@ -11,7 +11,7 @@
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",
-          "value": "https://duckduckgo.com/survey",
+          "value": "https://example.com/survey",
           "additionalParameters": {
             "queryParams": "atb;var;delta;osv;ddgv;last_duck_ai_usage"
           }
@@ -30,7 +30,7 @@
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",
-          "value": "https://duckduckgo.com/survey",
+          "value": "https://example.com/survey",
           "additionalParameters": {
             "queryParams": "atb;var;delta;osv;ddgv"
           }
@@ -49,7 +49,7 @@
         "primaryActionText": "Take Survey",
         "primaryAction": {
           "type": "survey",
-          "value": "https://duckduckgo.com/survey",
+          "value": "https://example.com/survey",
           "additionalParameters": {
             "queryParams": "atb;var;delta;osv;ddgv;last_search_state;last_duck_ai_usage"
           }

--- a/samples/macos/sample-survey.json
+++ b/samples/macos/sample-survey.json
@@ -1,0 +1,28 @@
+{
+  "version": 0,
+  "messages": [
+    {
+      "id": "macos-new-tab-survey-with-usage-state",
+      "surfaces": [
+        "new_tab_page"
+      ],
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Help Us Improve DuckDuckGo",
+        "descriptionText": "Share feedback about Search and Duck.ai.",
+        "placeholder": "Announce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://example.com/survey",
+          "additionalParameters": {
+            "queryParams": "atb;var;delta;osv;ddgv;last_search_state;last_duck_ai_usage"
+          }
+        }
+      },
+      "matchingRules": [],
+      "exclusionRules": []
+    }
+  ],
+  "rules": []
+}

--- a/samples/macos/sample-tab-bar.json
+++ b/samples/macos/sample-tab-bar.json
@@ -1,0 +1,28 @@
+{
+  "version": 0,
+  "messages": [
+    {
+      "id": "macos-tab-bar-survey-with-usage-state",
+      "surfaces": [
+        "tab_bar"
+      ],
+      "content": {
+        "messageType": "big_single_action",
+        "titleText": "Share Feedback",
+        "descriptionText": "Tell us about your Search and Duck.ai experience.",
+        "placeholder": "Announce",
+        "primaryActionText": "Take Survey",
+        "primaryAction": {
+          "type": "survey",
+          "value": "https://example.com/survey",
+          "additionalParameters": {
+            "queryParams": "atb;var;delta;osv;ddgv;last_search_state;last_duck_ai_usage"
+          }
+        }
+      },
+      "matchingRules": [],
+      "exclusionRules": []
+    }
+  ],
+  "rules": []
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only adds static JSON samples under `samples/`; no runtime or production config changes.
> 
> **Overview**
> Adds **sample remote-messaging configs** that demonstrate `big_single_action` messages whose primary action is a **survey** URL with `additionalParameters.queryParams`.
> 
> **iOS** (`samples/ios/sample-survey.json`) includes three new-tab-page examples: standard telemetry fields (`atb`, `var`, `delta`, `osv`, `ddgv`, `mo`, `locale`), Duck.ai usage (`last_duck_ai_usage`), and combined search + Duck.ai state (`last_search_state`, `last_duck_ai_usage`).
> 
> **macOS** adds a new-tab sample (`samples/macos/sample-survey.json`) and a **tab bar** surface sample (`samples/macos/sample-tab-bar.json`), both using search and Duck.ai usage query params. All samples use placeholder survey URLs and empty matching/exclusion rules for easy copy-paste testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caccd356a3b35ccb1d6c1d9cb0139eab5043330c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->