### PR TITLE
iOS: Set freemium PIR RMF entry point to 15%

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 126,
+  "version": 127,
   "messages": [
     {
       "id": "ios_pir_announcement_1",
@@ -889,7 +889,7 @@
     {
       "id": 20,
       "targetPercentile": {
-        "before": 0.05
+        "before": 0.15
       },
       "attributes": {
         "appVersion": {


### PR DESCRIPTION
## Asana task
https://app.asana.com/1/137249556945/project/72649045549333/task/1216592974254603?focus=true

## What

Updates `targetPercentile: { before: 0.15 }` on matching rule `20` (used by the `ios_pir_freemium_entry_point` message) and bumps the iOS config version `126 → 127`.

## Why

Per the [rollout plan](https://app.asana.com/1/137249556945/project/1203581873609357/task/1215530017305256?focus=true) we are ramping this message up to 15%.

## Scope

- Only rule `20` (the entry point) is changed.
- Scan-complete follow-up messages (rules `21` / `22`) are intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote config rollout only; no app logic changes, limited to widening an existing RMF message audience.
> 
> **Overview**
> Increases exposure of the **freemium Personal Information Removal** new-tab promo (`ios_pir_freemium_entry_point`) by changing matching rule **20**’s `targetPercentile.before` from **0.05 → 0.15**, so more eligible users see the “Start Free Scan” entry point.
> 
> Bumps `ios-config.json` version **126 → 127** so clients pick up the rollout. Scan-complete messages (rules **21** / **22**) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c184d8a4ceba93f575be6580593d0db3775a045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->