### PR TITLE
iOS: Set freemium PIR RMF entry point to 30%

### DIFF
--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -889,7 +889,7 @@
     {
       "id": 20,
       "targetPercentile": {
-        "before": 1.0
+        "before": 0.3
       },
       "attributes": {
         "appVersion": {

--- a/live/ios-config/ios-config.json
+++ b/live/ios-config/ios-config.json
@@ -1,5 +1,5 @@
 {
-  "version": 127,
+  "version": 128,
   "messages": [
     {
       "id": "ios_pir_announcement_1",
@@ -889,7 +889,7 @@
     {
       "id": 20,
       "targetPercentile": {
-        "before": 0.15
+        "before": 1.0
       },
       "attributes": {
         "appVersion": {


### PR DESCRIPTION
## Asana task
https://app.asana.com/1/137249556945/project/72649045549333/task/1216592974254603?focus=true

## What

Updates `targetPercentile: { before: 0.3 }` on matching rule `20` (used by the `ios_pir_freemium_entry_point` message) and bumps the iOS config version `127 → 128`.

## Why

Per the [rollout plan](https://app.asana.com/1/137249556945/project/1203581873609357/task/1215530017305256?focus=true) we are ramping this message up to 30%.

## Scope

- Only rule `20` (the entry point) is changed.
- Scan-complete follow-up messages (rules `21` / `22`) are intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Remote config rollout tweak for a promotional RMF message; no app logic or security-sensitive changes.
> 
> **Overview**
> Bumps the live iOS remote-messaging config **version** from `127` to `128`.
> 
> For matching rule **`20`** (used by the **`ios_pir_freemium_entry_point`** new-tab message), **`targetPercentile.before`** changes from **`0.15`** to **`0.3`**, widening the eligible audience for the freemium Personal Information Removal “Start Free Scan” entry point. No other rules or messages in the diff are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 943908abbf66ef71efbc4ca3d878730a47a02ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->